### PR TITLE
Add the ability to operate on complex numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ RPN is a mathematical notation in which the operator follows its operand(s). Thi
 Reading an expression from left to right, numbers are placed on a stack. The top four numbers are labeled `X`, `Y`, `Z`, and `T` from the top down. Although these labels are not shown when using the plugin, they are referenced in the README and the documentation. When an operator is encountered, one or more numbers (as needed by the operator) are popped from the stack, and the result of the operation is pushed back on the stack.
 
 ## Complex Numbers
-Most of the operators also will process complex numbers. The following web pages were used as reference for some of the more arcane derivations for complex numbers. Where the complete answer is an infinte number of answers, only the principal value is given. *As a side note, I don't know how useful these functions are, but it was a fun exercise implementing them. Leave a comment if you know of any practical use for, let's say, the hyperbolic arctangent of a complex number.*
+Most of the operators also will process complex numbers. The following Wikipedia pages were used as reference for some of the more arcane derivations for complex numbers. Where the complete answer is an infinte number of answers, only the principal value is given. *As a side note, I don't know how useful these functions are, but it was a fun exercise implementing them. Leave a comment if you know of any practical use for, let's say, the hyperbolic arctangent of a complex number.*
 * [logarithms](https://en.wikipedia.org/wiki/Complex_logarithm)
-* [exponentiation](https://www.wikiwand.com/en/exponential_function#computation_of_ab_where_both_a_and_b_are_complex)
+* [exponentiation](https://en.wikipedia.org/wiki/exponential_function#computation_of_ab_where_both_a_and_b_are_complex)
 * [ordinary trig functions](https://en.wikipedia.org/wiki/sine_and_cosine#complex_exponential_function_definitions)
 * [inverse trig functions](https://en.wikipedia.org/wiki/Inverse_trigonometric_functions#Extension_to_complex_plane)
 * [hyperbolic trig functions](https://en.wikipedia.org/wiki/Hyperbolic_sin#Hyperbolic_functions_for_complex_numbers)
@@ -39,48 +39,66 @@ Most of the operators also will process complex numbers. The following web pages
 
 ## Operands
 
-Numbers can be entered as integers, decimals, or in scientific notation. Complex numbers are entered as an ordered pair: `real,imaginary`. For example `1.2,3` represents `1.2+3i`.
+Numbers can be entered as integers, decimals, or in scientific notation. Complex numbers are entered as an ordered pair: `real,imaginary`. For example `1.2,-3` represents `1.2-3i`.
 
 ## Operators
 
-The ones marked with a ⭑ will work with complex operands.
+The operator categories and certain exceptional functions show the domain over which they are valid.
+* ℝ - real
+* ℕ - natural
+* ℂ - complex
 
-| Basic Arithmetic |                         | Powers & Logs     |                        |
-| :-:              | ---                     | :-:               | ---                    |
-| <kbd>+</kbd>⭑    | Addition                | <kbd>exp</kbd>⭑   | Raise e to the X power |
-| <kbd>-</kbd>⭑    | Subtraction             | <kbd>log</kbd>⭑   | Natural Log of X       |
-| <kbd>*</kbd>⭑    | Multiplication          | <kbd>log10</kbd>⭑ | Log (base 10) of X     |
-| <kbd>/</kbd>⭑    | Division                | <kbd>log2</kbd>⭑  | Log (base 2) of X      |
-| <kbd>div</kbd>   | Integer division        | <kbd>sqrt</kbd>⭑  | Square Root            |
-| <kbd>%</kbd>     | Modulus                 | <kbd>**</kbd>⭑    | Raise Y to the X power |
-| <kbd>abs</kbd>⭑  | Absolute value          | <kbd>\\</kbd>⭑    | Reciprocal             |
-| <kbd>arg</kbd>⭑  | The angle between X and the x-axis (complex only) |        |         |
-| <kbd>chs</kbd>⭑  | Negation                |                   |                        |
+### Basic Arithmetic - ℝ and ℂ
+* <kbd>+</kbd>   - Addition
+* <kbd>-</kbd>   - Subtraction
+* <kbd>*</kbd>   - Multiplication
+* <kbd>/</kbd>   - Division
+* <kbd>div</kbd> - Integer division
+* <kbd>%</kbd>   - Modulus (ℝ only)
+* <kbd>abs</kbd> - Absolute value
+* <kbd>arg</kbd> - The angle between X and the x-axis
+* <kbd>chs</kbd> - Negation
 
-| Trigonometry | Base            | Inverse          | Hyperbolic       | Inverse Hyperbolic |
-| ---          | :-:             | :-:              | :-:              | :-:                |
-| Sine         | <kbd>sin</kbd>⭑ | <kbd>asin</kbd>⭑ | <kbd>sinh</kbd>⭑ | <kbd>asinh</kbd>⭑  |
-| Cosine       | <kbd>cos</kbd>⭑ | <kbd>acos</kbd>⭑ | <kbd>cosh</kbd>⭑ | <kbd>acosh</kbd>⭑  |
-| Tangent      | <kbd>tan</kbd>⭑ | <kbd>atan</kbd>⭑ | <kbd>tanh</kbd>⭑ | <kbd>atanh</kbd>⭑  |
-| Cosecant     | <kbd>csc</kbd>⭑ | <kbd>acsc</kbd>⭑ | <kbd>csch</kbd>⭑ | <kbd>acsch</kbd>⭑  |
-| Secant       | <kbd>sec</kbd>⭑ | <kbd>asec</kbd>⭑ | <kbd>sech</kbd>⭑ | <kbd>asech</kbd>⭑  |
-| Cotangent    | <kbd>cot</kbd>⭑ | <kbd>acot</kbd>⭑ | <kbd>coth</kbd>⭑ | <kbd>acoth</kbd>⭑  |
+### Powers & Logs - ℝ and ℂ
+* <kbd>exp</kbd>   - Raise e to the X power
+* <kbd>log</kbd>   - Natural Log of X
+* <kbd>log10</kbd> - Log (base 10) of X
+* <kbd>log2</kbd>  - Log (base 2) of X
+* <kbd>sqrt</kbd>  - Square Root
+* <kbd>**</kbd>    - Raise Y to the X power
+* <kbd>\\</kbd>    - Reciprocal
 
-| Bitwise       |                                  | Rounding          |                               |
-| :-:           | ---                              | :-:               | ---                           |
-| <kbd>&</kbd>  | AND                              | <kbd>floor</kbd>⭑ | Round down to nearest integer |
-| <kbd>\|</kbd> | OR                               | <kbd>ceil</kbd>⭑  | Round up to nearest integer   |
-| <kbd>^</kbd>  | XOR                              | <kbd>round</kbd>⭑ | Round to nearest integer      |
-| <kbd><<</kbd> | Left Shift (Y shifted X places)  | <kbd>trunc</kbd>⭑ | Truncate to integer           |
-| <kbd>>></kbd> | Right Shift (Y shifted X places) |                   |                               |
-| <kbd>~</kbd>  | 1's complement                   |                   |                               |
+### Trigonometry - ℝ and ℂ
+* Sine      - <kbd>sin</kbd>   <kbd>asin</kbd>   <kbd>sinh</kbd>   <kbd>asinh</kbd>
+* Cosine    - <kbd>cos</kbd>   <kbd>acos</kbd>   <kbd>cosh</kbd>   <kbd>acosh</kbd>
+* Tangent   - <kbd>tan</kbd>   <kbd>atan</kbd>   <kbd>tanh</kbd>   <kbd>atanh</kbd>
+* Cosecant  - <kbd>csc</kbd>   <kbd>acsc</kbd>   <kbd>csch</kbd>   <kbd>acsch</kbd>
+* Secant    - <kbd>sec</kbd>   <kbd>asec</kbd>   <kbd>sech</kbd>   <kbd>asech</kbd>
+* Cotangent - <kbd>cot</kbd>   <kbd>acot</kbd>   <kbd>coth</kbd>   <kbd>acoth</kbd>
 
-| Constants      |                 | Other          |                          |
-| :-:            | ---             | :-:            | ---                      |
-| <kbd>pi</kbd>  | 3.141592653.... | <kbd>hrs</kbd> | Convert Z:Y:X to hours   |
-| <kbd>e</kbd>   | 2.718281828...  | <kbd>hms</kbd> | Convert X hours to Z:Y:X |
-| <kbd>phi</kbd> | 0.618033989...  |                |                          |
-| <kbd>i</kbd>   | 0+1i            |                |                          |
+### Rounding - ℝ and ℂ
+* <kbd>floor</kbd> - Round down to nearest integer
+* <kbd>ceil</kbd>  - Round up to nearest integer
+* <kbd>round</kbd> - Round to nearest integer
+* <kbd>trunc</kbd> - Truncate to integer
+
+### Bitwise - ℕ
+* <kbd>&</kbd>  - AND
+* <kbd>\|</kbd> - OR
+* <kbd>^</kbd>  - XOR
+* <kbd><<</kbd> - Left Shift (Y shifted X places)
+* <kbd>>></kbd> - Right Shift (Y shifted X places)
+* <kbd>~</kbd>  - 1's complement
+
+### Constants - ℝ and ℂ
+* <kbd>pi</kbd>  - 3.141592653...
+* <kbd>e</kbd>   - 2.718281828...
+* <kbd>phi</kbd> - the golden ratio, 0.618033989...
+* <kbd>i</kbd>   - 0+1i
+
+### Other - ℝ
+* <kbd>hrs</kbd> - Convert Z:Y:X to X hours
+* <kbd>hms</kbd> - Convert X hours to Z:Y:X
 
 ## Errors and Enhancements
 Please don't use this for important calculations, or at the very least double-check them with another calculator. It's quite possible computational errors made their way in, despite all efforts to ensure accuracy. This was mainly an exercise to learn lua and Neovim plugins by porting my prior [Ruby and Erlang rpn calculators](https://github.com/PhilRunninger/rpn).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ RPN is a mathematical notation in which the operator follows its operand(s). Thi
 Reading an expression from left to right, numbers are placed on a stack. The top four numbers are labeled `X`, `Y`, `Z`, and `T` from the top down. Although these labels are not shown when using the plugin, they are referenced in the README and the documentation. When an operator is encountered, one or more numbers (as needed by the operator) are popped from the stack, and the result of the operation is pushed back on the stack.
 
 ## Complex Numbers
-Most of the operators also will process complex numbers. The following Wikipedia pages were used as reference for some of the more arcane derivations for complex numbers. Where the complete answer is an infinte number of answers, only the principal value is given. *As a side note, I don't know how useful these functions are, but it was a fun exercise implementing them. Leave a comment if you know of any practical use for, let's say, the hyperbolic arctangent of a complex number.*
+Most of the operators also will process complex numbers. The following Wikipedia pages were used as reference for some of the more arcane derivations for complex numbers. Where the complete answer is an infinte number of answers, only the principal value is given.
 * [logarithms](https://en.wikipedia.org/wiki/Complex_logarithm)
 * [exponentiation](https://en.wikipedia.org/wiki/exponential_function#computation_of_ab_where_both_a_and_b_are_complex)
 * [ordinary trig functions](https://en.wikipedia.org/wiki/sine_and_cosine#complex_exponential_function_definitions)
@@ -100,7 +100,9 @@ The operator categories and certain exceptional functions show the domain over w
 * <kbd>hrs</kbd> - Convert Z:Y:X to X hours
 * <kbd>hms</kbd> - Convert X hours to Z:Y:X
 
-## Errors and Enhancements
-Please don't use this for important calculations, or at the very least double-check them with another calculator. It's quite possible computational errors made their way in, despite all efforts to ensure accuracy. This was mainly an exercise to learn lua and Neovim plugins by porting my prior [Ruby and Erlang rpn calculators](https://github.com/PhilRunninger/rpn).
+## Feedback
+Please don't rely on this for important calculations, or at the very least double-check them with another calculator. It's quite possible computational errors made their way in, despite all efforts to ensure accuracy. This was mainly an exercise to learn lua and Neovim plugins by porting my prior [Ruby and Erlang rpn calculators](https://github.com/PhilRunninger/rpn).
 
 If you spot any errors, or have suggestions for improvements, added operators, etc., create an issue or a pull request.
+
+Finally, I don't know how useful some of the complex number functions are. It was a fun exercise implementing them, but was it just that, an exercise? Leave a comment (in an issue is fine) if you know of any real-world (pun intended) use for, let's say, the hyperbolic arctangent of a complex number, or any of the others for that matter.

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 ## Installation
 
-Use your favorite plugin manager to install this plugin. [vim-pathogen](https://github.com/tpope/vim-pathogen), [Vundle.vim](https://github.com/VundleVim/Vundle.vim), [vim-plug](https://github.com/junegunn/vim-plug), [neobundle.vim](https://github.com/Shougo/neobundle.vim), and [Packer.nvim](https://github.com/wbthomason/packer.nvim) are some of the more popular ones. A lengthy discussion of these and other managers can be found on [vi.stackexchange.com](https://vi.stackexchange.com/questions/388/what-is-the-difference-between-the-vim-plugin-managers).
+Use your favorite plugin manager to install this plugin. [vim-pathogen](https://github.com/tpope/vim-pathogen), [vim-plug](https://github.com/junegunn/vim-plug), and [Packer.nvim](https://github.com/wbthomason/packer.nvim) are some of the more popular ones. A lengthy discussion of these and other managers can be found on [vi.stackexchange.com](https://vi.stackexchange.com/questions/388/what-is-the-difference-between-the-vim-plugin-managers).
 
-If you have no favorite, or want to manage your plugins without 3rd-party dependencies, I recommend using packages, as described in Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g)
+If you have no favorite, or want to manage your plugins without 3rd-party dependencies, use packages, as described in Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g)
 
 ## Setup
-
+Add **rpncalc** to the list of sources in your **nvim-cmp** setup, as shown in the following snippet.
 ```
 require'cmp'.setup {
   sources = {
@@ -21,51 +21,68 @@ require'cmp'.setup {
 
 RPN is a mathematical notation in which the operator follows its operand(s). This means there is no need for parentheses. Here are some examples:
 * Add 956 and 37: `956 37 +`
-* Divide 452 by 12 (Remember, division isn't commutative.): `452 12 /`
-* Find the tangent of 28 degrees: `28 rad tan`
-* Solve `3x²+13x-10 = 0` using the quadratic formula:
-    * `13 chs 13 2 ** 4 3 10 chs * * - sqrt + 2 3 * /`
-    * `13 chs 13 2 ** 4 3 10 chs * * - sqrt - 2 3 * /`
+* Divide 452 by 12 (Remember, the order of operands is important.): `452 12 /`
+* Find the arctangent of 1/√3: `3 sqrt \ atan deg`
+* Evaluate `3x²+13x-10` at `x=4`:
+    * `3 4 2 ** * 13 4 * + 10 -`
 
-Reading an expression from left to right, numbers are placed on a stack. When an operator is encountered one or more numbers (as needed by the operator) are popped from the stack and the result of the operation is pushed back on the stack.
+Reading an expression from left to right, numbers are placed on a stack. The top four numbers are labeled `X`, `Y`, `Z`, and `T` from the top down. Although these labels are not shown when using the plugin, they are referenced in the README and the documentation. When an operator is encountered, one or more numbers (as needed by the operator) are popped from the stack, and the result of the operation is pushed back on the stack.
+
+## Complex Numbers
+Most of the operators also will process complex numbers. The following web pages were used as reference for some of the more arcane derivations for complex numbers. Where the complete answer is an infinte number of answers, only the principal value is given. *As a side note, I don't know how useful these functions are, but it was a fun exercise implementing them. Leave a comment if you know of any practical use for, let's say, the hyperbolic arctangent of a complex number.*
+* [logarithms](https://en.wikipedia.org/wiki/Complex_logarithm)
+* [exponentiation](https://www.wikiwand.com/en/exponential_function#computation_of_ab_where_both_a_and_b_are_complex)
+* [ordinary trig functions](https://en.wikipedia.org/wiki/sine_and_cosine#complex_exponential_function_definitions)
+* [inverse trig functions](https://en.wikipedia.org/wiki/Inverse_trigonometric_functions#Extension_to_complex_plane)
+* [hyperbolic trig functions](https://en.wikipedia.org/wiki/Hyperbolic_sin#Hyperbolic_functions_for_complex_numbers)
+* [inverse hyperbolic trig functions](https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions)
 
 ## Operands
 
-Numbers can be entered as integers, decimals, or in scientific notation.
+Numbers can be entered as integers, decimals, or in scientific notation. Complex numbers are entered as an ordered pair: `real,imaginary`. For example `1.2,3` represents `1.2+3i`.
 
 ## Operators
 
-| Basic Arithmetic |                  | Powers & Logs    |                        |
-| :-:              | ---              | :-:              | ---                    |
-| <kbd>+</kbd>     | Addition         | <kbd>exp</kbd>   | Raise e to the x power |
-| <kbd>-</kbd>     | Subtraction      | <kbd>log</kbd>   | Natural Log of x       |
-| <kbd>*</kbd>     | Multiplication   | <kbd>log10</kbd> | Log (base 10) of x     |
-| <kbd>/</kbd>     | Division         | <kbd>log2</kbd>  | Log (base 2) of x      |
-| <kbd>div</kbd>   | Integer division | <kbd>sqrt</kbd>  | Square Root            |
-| <kbd>%</kbd>     | Modulus          | <kbd>**</kbd>    | Exponentiation         |
-| <kbd>abs</kbd>   | Absolute value   | <kbd>\</kbd>     | Reciprocal             |
-| <kbd>chs</kbd>   | Negation         |                  |                        |
+The ones marked with a ⭑ will work with complex operands.
 
-| Trigonometry | Base           | Inverse         | Hyperbolic      | Inverse Hyperbolic |
-| ---          | :-:            | :-:             | :-:             | :-:                |
-| Sine         | <kbd>sin</kbd> | <kbd>asin</kbd> | <kbd>sinh</kbd> | <kbd>asinh</kbd>   |
-| Cosine       | <kbd>cos</kbd> | <kbd>acos</kbd> | <kbd>cosh</kbd> | <kbd>acosh</kbd>   |
-| Tangent      | <kbd>tan</kbd> | <kbd>atan</kbd> | <kbd>tanh</kbd> | <kbd>atanh</kbd>   |
-| Cosecant     | <kbd>csc</kbd> | <kbd>acsc</kbd> | <kbd>csch</kbd> | <kbd>acsch</kbd>   |
-| Secant       | <kbd>sec</kbd> | <kbd>asec</kbd> | <kbd>sech</kbd> | <kbd>asech</kbd>   |
-| Cotangent    | <kbd>cot</kbd> | <kbd>acot</kbd> | <kbd>coth</kbd> | <kbd>acoth</kbd>   |
+| Basic Arithmetic |                         | Powers & Logs     |                        |
+| :-:              | ---                     | :-:               | ---                    |
+| <kbd>+</kbd>⭑    | Addition                | <kbd>exp</kbd>⭑   | Raise e to the X power |
+| <kbd>-</kbd>⭑    | Subtraction             | <kbd>log</kbd>⭑   | Natural Log of X       |
+| <kbd>*</kbd>⭑    | Multiplication          | <kbd>log10</kbd>⭑ | Log (base 10) of X     |
+| <kbd>/</kbd>⭑    | Division                | <kbd>log2</kbd>⭑  | Log (base 2) of X      |
+| <kbd>div</kbd>   | Integer division        | <kbd>sqrt</kbd>⭑  | Square Root            |
+| <kbd>%</kbd>     | Modulus                 | <kbd>**</kbd>⭑    | Raise Y to the X power |
+| <kbd>abs</kbd>⭑  | Absolute value          | <kbd>\\</kbd>⭑    | Reciprocal             |
+| <kbd>arg</kbd>⭑  | The angle between X and the x-axis (complex only) |        |         |
+| <kbd>chs</kbd>⭑  | Negation                |                   |                        |
 
-| Bitwise       |                | Rounding         |                               |
-| :-:           | ---            | :-:              | ---                           |
-| <kbd>&</kbd>  | AND            | <kbd>floor</kbd> | Round down to nearest integer |
-| <kbd>\| </kbd>| OR             | <kbd>ceil</kbd>  | Round up to nearest integer   |
-| <kbd>^</kbd>  | XOR            | <kbd>round</kbd> | Round to nearest integer      |
-| <kbd><<</kbd> | Left Shift     | <kbd>trunc</kbd> | Truncate to integer           |
-| <kbd>>></kbd> | Right Shift    |                  |                               |
-| <kbd>~</kbd>  | 1's complement |                  |                               |
+| Trigonometry | Base            | Inverse          | Hyperbolic       | Inverse Hyperbolic |
+| ---          | :-:             | :-:              | :-:              | :-:                |
+| Sine         | <kbd>sin</kbd>⭑ | <kbd>asin</kbd>⭑ | <kbd>sinh</kbd>⭑ | <kbd>asinh</kbd>⭑  |
+| Cosine       | <kbd>cos</kbd>⭑ | <kbd>acos</kbd>⭑ | <kbd>cosh</kbd>⭑ | <kbd>acosh</kbd>⭑  |
+| Tangent      | <kbd>tan</kbd>⭑ | <kbd>atan</kbd>⭑ | <kbd>tanh</kbd>⭑ | <kbd>atanh</kbd>⭑  |
+| Cosecant     | <kbd>csc</kbd>⭑ | <kbd>acsc</kbd>⭑ | <kbd>csch</kbd>⭑ | <kbd>acsch</kbd>⭑  |
+| Secant       | <kbd>sec</kbd>⭑ | <kbd>asec</kbd>⭑ | <kbd>sech</kbd>⭑ | <kbd>asech</kbd>⭑  |
+| Cotangent    | <kbd>cot</kbd>⭑ | <kbd>acot</kbd>⭑ | <kbd>coth</kbd>⭑ | <kbd>acoth</kbd>⭑  |
+
+| Bitwise       |                                  | Rounding          |                               |
+| :-:           | ---                              | :-:               | ---                           |
+| <kbd>&</kbd>  | AND                              | <kbd>floor</kbd>⭑ | Round down to nearest integer |
+| <kbd>\|</kbd> | OR                               | <kbd>ceil</kbd>⭑  | Round up to nearest integer   |
+| <kbd>^</kbd>  | XOR                              | <kbd>round</kbd>⭑ | Round to nearest integer      |
+| <kbd><<</kbd> | Left Shift (Y shifted X places)  | <kbd>trunc</kbd>⭑ | Truncate to integer           |
+| <kbd>>></kbd> | Right Shift (Y shifted X places) |                   |                               |
+| <kbd>~</kbd>  | 1's complement                   |                   |                               |
 
 | Constants      |                 | Other          |                          |
 | :-:            | ---             | :-:            | ---                      |
 | <kbd>pi</kbd>  | 3.141592653.... | <kbd>hrs</kbd> | Convert Z:Y:X to hours   |
 | <kbd>e</kbd>   | 2.718281828...  | <kbd>hms</kbd> | Convert X hours to Z:Y:X |
 | <kbd>phi</kbd> | 0.618033989...  |                |                          |
+| <kbd>i</kbd>   | 0+1i            |                |                          |
+
+## Errors and Enhancements
+Please don't use this for important calculations, or at the very least double-check them with another calculator. It's quite possible computational errors made their way in, despite all efforts to ensure accuracy. This was mainly an exercise to learn lua and Neovim plugins by porting my prior [Ruby and Erlang rpn calculators](https://github.com/PhilRunninger/rpn).
+
+If you spot any errors, or have suggestions for improvements, added operators, etc., create an issue or a pull request.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use your favorite plugin manager to install this plugin. [vim-pathogen](https://
 If you have no favorite, or want to manage your plugins without 3rd-party dependencies, use packages, as described in Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g)
 
 ## Setup
-Add **rpncalc** to the list of sources in your **nvim-cmp** setup, as shown in the following snippet.
+There is no setup required specifically for this plugin; however, you need to add **rpncalc** to the list of sources in your **nvim-cmp** setup. The following snippet shows how to do that.
 ```
 require'cmp'.setup {
   sources = {
@@ -20,11 +20,10 @@ require'cmp'.setup {
 ## How Does RPN Work?
 
 RPN is a mathematical notation in which the operator follows its operand(s). This means there is no need for parentheses. Here are some examples:
-* Add 956 and 37: `956 37 +`
-* Divide 452 by 12 (Remember, the order of operands is important.): `452 12 /`
-* Find the arctangent of 1/√3: `3 sqrt \ atan deg`
-* Evaluate `3x²+13x-10` at `x=4`:
-    * `3 4 2 ** * 13 4 * + 10 -`
+* Add **956** and **37**: `956 37 +`
+* Divide **452** by **12** (Remember, the order of operands is important.): `452 12 /`
+* Find the **arctangent** of **1/√3**: `3 sqrt \ atan deg`
+* Evaluate **3x²+13x-10** at **x=4**: `3 4 2 ** * 13 4 * + 10 -`
 
 Reading an expression from left to right, numbers are placed on a stack. The top four numbers are labeled `X`, `Y`, `Z`, and `T` from the top down. Although these labels are not shown when using the plugin, they are referenced in the README and the documentation. When an operator is encountered, one or more numbers (as needed by the operator) are popped from the stack, and the result of the operation is pushed back on the stack.
 
@@ -86,19 +85,19 @@ The operator categories and certain exceptional functions show the domain over w
 * <kbd>&</kbd>  - AND
 * <kbd>\|</kbd> - OR
 * <kbd>^</kbd>  - XOR
+* <kbd>~</kbd>  - NOT
 * <kbd><<</kbd> - Left Shift (Y shifted X places)
 * <kbd>>></kbd> - Right Shift (Y shifted X places)
-* <kbd>~</kbd>  - 1's complement
 
 ### Constants - ℝ and ℂ
 * <kbd>pi</kbd>  - 3.141592653...
 * <kbd>e</kbd>   - 2.718281828...
-* <kbd>phi</kbd> - the golden ratio, 0.618033989...
+* <kbd>phi</kbd> - the golden ratio, 1.618033989...
 * <kbd>i</kbd>   - 0+1i
 
 ### Other - ℝ
-* <kbd>hrs</kbd> - Convert Z:Y:X to X hours
-* <kbd>hms</kbd> - Convert X hours to Z:Y:X
+* <kbd>hrs</kbd> - Convert (Z hours:Y minutes:X seconds) to X hours
+* <kbd>hms</kbd> - Convert X hours to (Z hours:Y minutes:X seconds)
 
 ## Feedback
 Please don't rely on this for important calculations, or at the very least double-check them with another calculator. It's quite possible computational errors made their way in, despite all efforts to ensure accuracy. This was mainly an exercise to learn lua and Neovim plugins by porting my prior [Ruby and Erlang rpn calculators](https://github.com/PhilRunninger/rpn).

--- a/doc/cmp-rpncalc.txt
+++ b/doc/cmp-rpncalc.txt
@@ -14,87 +14,105 @@ nationality of logician Jan Łukasiewicz, who invented Polish notation in 1924.
                                                                   *rpn-operands*
 
 Numbers, formally called operands, are pushed onto a stack in the order they
-are read by the processor. Supported formats are: integers, decimals, and
-scientific notation. The top number on the stack is called X, with Y, Z, W,
-and other unnamed positions positioned below. When an operator is encountered,
-X and if necessary, other numbers are taken off the stack, and the result of
-the operation is placed back on the stack.
+are read by the processor. The top number on the stack is called X, with Y, Z,
+W, and other unnamed positions underneath. When an operator is encountered, X
+and if necessary, other numbers are taken off the stack, and the result of the
+operation is placed back on the stack.
+
+Supported number formats are: integers, decimals, and scientific notation.
+Complex numbers are entered as ordered pairs: `real,imaginary`. For example
+`1.2,-3` evaluates to `1.2-3i`.
 
 ==============================================================================
                                                                  *rpn-operators*
-|Basic_Arithmetic|  `+  -  *  /  div  %  abs  chs`
-|Powers_&_Logs|     `exp  ln  log  log2  sqrt  **  \`
+
+Most operators work on complex numbers. Exceptions are noted below.
+
+|Basic_Arithmetic|  `+      -      *      /      div    %     abs  arg  chs`
+|Powers_&_Logs|     `exp    ln     log    log2   logx   sqrt  **   \`
 |Trigonometry|      `sin    cos    tan    csc    sec    cot`
                   `asin   acos   atan   acsc   asec   acot`
                   `sinh   cosh   tanh   csch   sech   coth`
                   `asinh  acosh  atanh  acsch  asech  acoth`
-|Bitwise|           `&  |  ^  <<  >>  ~`
+|Bitwise|           `&      |      ^      <<     >>     ~`
 |Rounding|          `floor  ceil  round  trunc`
-|Constants|         `pi  e  phi`
-|Other|             `hrs  hms`
+|Constants|         `pi     e     phi    i`
+|Other|             `hrs    hms`
 
 ==============================================================================
 *Basic_Arithmetic*                                           *rpn-basic-operators*
 
-  `+`    Addition               `8 2 +`    becomes `10`
-  `-`    Subtraction            `8 2 -`    becomes `6`
-  `*`    Multiplication         `8 2 *`    becomes `16`
-  `/`    Division               `8 2 *`    becomes `4`
-  `div`  Integer Division       `25 7 div` becomes `3`
-  `%`    Remainder              `25 7 %`   becomes `4`
-  `abs`  Absolute Value         `-9`       becomes `9`
-  `chs`  Change Sign (Negation) `10 chs`   becomes `-10`
+  `+`    Addition
+  `-`    Subtraction
+  `*`    Multiplication
+  `/`    Division
+  `div`  Integer Division
+  `%`    Remainder of Y / X (real numbers only)
+  `abs`  Absolute Value
+  `arg`  Argument, the angle between x-axis and X
+  `chs`  Change Sign of X
 
 *Powers_&_Logs*                            *rpn-power-operators* *rpn-log-operators*
 
-  `exp`   Exponential function  `1 exp`    becomes `2.718281828...`
-  `ln`    Natural log function  `2.718 ln` becomes `0.99989631572895`
-  `log`   Common log function   `1000 log` becomes `3`
-  `log2`  Log, base 2 function  `512 log2` becomes `9`
-  `sqrt`  Square root           `121 sqrt` becomes `11`
-  `**`    Exponentiation (y^x)  `3 4 **`   becomes `81`
-  `\`     Reciprocal            `4 \`      becomes `0.25`
+  `exp`   Exponential function: e to the X power
+  `ln`    Natural log: ln(X)
+  `log`   Common log (base 10) of X
+  `log2`  Log (base 2) of X
+  `logx`  Log (base X) of Y
+  `sqrt`  Square root of X
+  `**`    Exponentiation: Y to the X power
+  `\`     Reciprocal of X
 
 *Trigonometry*                                        *rpn-trigonometry-operators*
+
+  `deg`  Convert X from radians to degrees
+  `rad`  Convert X from degrees to radians
+
   Ordinary
-    `sin`    Sine of x radians         `asin`   Inverse
-    `cos`    Cosine of x radians       `acos`   Inverse
-    `tan`    Tangent of x radians      `atan`   Inverse
-    `csc`    Cosecant of x radians     `acsc`   Inverse
-    `sec`    Secant of x radians       `asec`   Inverse
-    `cot`    Cotangent of x radians    `acot`   Inverse
+    `sin`    Sine of X radians         `asin`   Inverse
+    `cos`    Cosine of X radians       `acos`   Inverse
+    `tan`    Tangent of X radians      `atan`   Inverse
+    `csc`    Cosecant of X radians     `acsc`   Inverse
+    `sec`    Secant of X radians       `asec`   Inverse
+    `cot`    Cotangent of X radians    `acot`   Inverse
 
   Hyperbolic
-    `sinh`   Hyperbolic Sine of x radians        `asinh`  Inverse
-    `cosh`   Hyperbolic Cosine of x radians      `acosh`  Inverse
-    `tanh`   Hyperbolic Tangent of x radians     `atanh`  Inverse
-    `csch`   Hyperbolic Cosecant of x radians    `acsch`  Inverse
-    `sech`   Hyperbolic Secant of x radians      `asech`  Inverse
-    `coth`   Hyperbolic Cotangent of x radians   `acoth`  Inverse
+    `sinh`   Hyperbolic Sine of X radians        `asinh`  Inverse
+    `cosh`   Hyperbolic Cosine of X radians      `acosh`  Inverse
+    `tanh`   Hyperbolic Tangent of X radians     `atanh`  Inverse
+    `csch`   Hyperbolic Cosecant of X radians    `acsch`  Inverse
+    `sech`   Hyperbolic Secant of X radians      `asech`  Inverse
+    `coth`   Hyperbolic Cotangent of X radians   `acoth`  Inverse
 
 *Bitwise*                                                  *rpn-bitwise-operators*
 
-  `&`  AND           `10 7 &`  becomes `2` (In binary, 1010 AND 111 = 10)
-  `|`  OR            `10 6 |`  becomes `14`            (1010 OR 110 = 1110)
-  `^`  XOR           `10 3 ^`  becomes `9`             (1010 XOR 11 = 1001)
-  `<<` Left Shift    `5 2 <<`  becomes `20`                   (101 -> 10100)
-  `>>` Right Shift   `58 2 >>` becomes `14`                (111010 -> 1110)
-  `~` 1's Complement `42 ~`    becomes `-43`    (101010 -> 1111111111110101)
+  These functions work best with natural numbers, and don't work at all with
+  complex numbers.
+
+  `&`  AND         `10 7 &`  is `2`  In binary, 1010 AND 111 = 10
+  `|`  OR          `10 6 |`  is `14`             1010 OR 110 = 1110
+  `^`  XOR         `10 3 ^`  is `9`              1010 XOR 11 = 1001
+  `~`  NOT         `42 ~`    is `-43`               101010 ~ = 1...111111110101
+  `<<` Left Shift  `5 3 <<`  is `40`                  101 << = 101000
+  `>>` Right Shift `58 2 >>` is `14`               111010 >> = 1110
 
 *Rounding*                                                *rpn-rounding-operators*
 
-  `floor` Round down towards -infinity        `-3.5 floor` becomes `-4`
-  `ceil`  Round up towards +infinity          `6.2 ceil`   becomes `7`
-  `round` Round up or down to nearest integer `2.7 round`  becomes `3`
-  `trunc` Round toward zero                   `-5.8 trunc` becomes `-5`
+  `floor` Round down towards -infinity
+  `ceil`  Round up towards +infinity
+  `round` Round up or down to nearest integer
+  `trunc` Round toward zero
 
 *Constants*                                                        *rpn-constants*
 
-  `pi`  - A circle's circumference divided by its diameter: `3.1415926535...`
+  `pi`  - The ratio of a circle's circumference to its diameter: `3.1415926535...`
   `e`   - Euler's number: `2.7182818284590...`
   `phi` - The golden ratio: `1.6180339887499...`
+  `i`   - The imaginary unit: `0+1i`
 
 *Other*                                                      *rpn-other-operators*
 
-  `hrs` - Convert hours, minutes, seconds to hours. `3 37 30 hrs` becomes `3.625`
-  `hms` - Convert hours to hours, minutes, seconds. `3.625 hms` becomes `3 37 30`
+  These functions work only with real numbers.
+
+  `hrs` - Convert hours, minutes, seconds to hours. `3 37 30 hrs` is `3.625`
+  `hms` - Convert hours to hours, minutes, seconds. `3.625 hms` is `3 37 30`

--- a/doc/cmp-rpncalc.txt
+++ b/doc/cmp-rpncalc.txt
@@ -23,7 +23,7 @@ the operation is placed back on the stack.
 ==============================================================================
                                                                  *rpn-operators*
 |Basic_Arithmetic|  `+  -  *  /  div  %  abs  chs`
-|Powers_&_Logs|     `exp  log  log10  log2  sqrt  **  \`
+|Powers_&_Logs|     `exp  ln  log  log2  sqrt  **  \`
 |Trigonometry|      `sin    cos    tan    csc    sec    cot`
                   `asin   acos   atan   acsc   asec   acot`
                   `sinh   cosh   tanh   csch   sech   coth`
@@ -47,13 +47,13 @@ the operation is placed back on the stack.
 
 *Powers_&_Logs*                            *rpn-power-operators* *rpn-log-operators*
 
-  `exp`    Exponential function  `1 exp`      becomes `2.718281828...`
-  `log`    Natural log function  `2.718 log`  becomes `0.99989631572895`
-  `log10`  Common log function   `1000 log10` becomes `3`
-  `log2`   Log, base 2 function  `512 log2`   becomes `9`
-  `sqrt`   Square root           `121 sqrt`   becomes `11`
-  `**`     Exponentiation (y^x)  `3 4 **`     becomes `81`
-  `\`      Reciprocal            `4 \`        becomes `0.25`
+  `exp`   Exponential function  `1 exp`    becomes `2.718281828...`
+  `ln`    Natural log function  `2.718 ln` becomes `0.99989631572895`
+  `log`   Common log function   `1000 log` becomes `3`
+  `log2`  Log, base 2 function  `512 log2` becomes `9`
+  `sqrt`  Square root           `121 sqrt` becomes `11`
+  `**`    Exponentiation (y^x)  `3 4 **`   becomes `81`
+  `\`     Reciprocal            `4 \`      becomes `0.25`
 
 *Trigonometry*                                        *rpn-trigonometry-operators*
   Ordinary

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -17,7 +17,9 @@ math.trunc = function(x) return x>=0 and math.floor(x) or math.ceil(x) end -- Ro
 
 local op= {}
 
--- Basic Arithmetic --------------------------------------------------------------------------------
+-- #############################################################################################
+-- ############################################################################ Basic Arithmetic
+-- #############################################################################################
 op[ [[+]] ] = function()  -- Addtion
     local x,y = pop(), pop()
     if math.isreal(x)        and math.isreal(y)    then push(x + y)
@@ -78,7 +80,9 @@ op[ [[chs]] ]   = function() -- Change Sign
 end
 
 
--- Rounding --------------------------------------------------------------------------------
+-- #############################################################################################
+-- #################################################################################### Rounding
+-- #############################################################################################
 op[ [[floor]] ] = function() -- Floor - round down to nearest integer
     local x=pop()
     if math.isreal(x)        then push(math.floor(x))
@@ -105,8 +109,9 @@ op[ [[trunc]] ] = function() -- Round toward zero
 end
 
 
--- Powers & Logs --------------------------------------------------------------------------------
--- ln(a+bi)   =   ln(re^it)  =  ln(r)+ln(e^it)  =  ln(r)+it
+-- #############################################################################################
+-- ############################################################################### Powers & Logs
+-- #############################################################################################
 op[ [[log]] ]   = function() -- Natural log of x
         local x=pop()
     if math.iscomplex(x) then
@@ -155,25 +160,9 @@ op[ [[\]] ]     = function() push(-1); pcall(op[ [[**]] ]) end -- Reciprocal
 op[ [[sqrt]] ]  = function() push(0.5); pcall(op[ [[**]] ]) end -- Square root of x
 
 
--- Trigonometry --------------------------------------------------------------------------------
-op[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
-op[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
---
--- Using these identities, we can calculate trig values of complex numbers:
---    sin(z) = (e^iz - e^-iz) / 2i         cos(z) = (e^iz + e^-iz) / 2
---    sin(iz) = (e^iiz - e^-iiz) / 2i      cos(iz) = (e^iiz + e^-iiz) / 2
---            = i*(e^z - e^-z) / 2                 = (e^-z + e^z) / 2
---            = i*sinh(z)                          = cosh(z)
---
--- sin(a+bi) = sin(a)*cos(bi) + cos(a)*sin(bi)*i   =   sin(a)*cosh(b) + cos(a)*sinh(b)*i
--- cos(a+bi) = cos(z)*cos(bi) - sin(a)*sin(bi)*i   =   cos(a)*cosh(b) - sin(a)*sinh(b)*i
---
--- sinh(a+bi) = -i*sin(ia+ibi) = -i*sin(-b+ai) = -i*(sin(-b)*cosh(a) + cos(-b)*sinh(a)*i) =  cos(b)*sinh(a) + sin(b)*cosh(a)*i
--- cosh(a+bi) = cos(ia+ibi)    = cos(-b+ai)    = cos(-b)*cosh(a) - sin(-b)*sinh(a)*i =   cos(b)*cosh(a) + sin(b)*sinh(a)*i
---
--- Then, as usual, tan = sin / cos,      csc = 1 / sin,     sec = 1 / cos,     cot = 1 / tan
---                 tanh = sinh / cosh,   csch = 1 / sinh,   sech = 1 / cosh,   coth = 1 / tanh
---
+-- #############################################################################################
+-- ################################################################################ Trigonometry
+-- #############################################################################################
 op[ [[sin]] ]   = function() -- Sine
     local x=pop()
     if math.iscomplex(x) then
@@ -201,6 +190,7 @@ end
 op[ [[csc]] ]   = function() pcall(op[ [[sin]] ]); pcall(op[ [[\]] ]); end -- Cosecant
 op[ [[sec]] ]   = function() pcall(op[ [[cos]] ]); pcall(op[ [[\]] ]); end -- Secant
 op[ [[cot]] ]   = function() pcall(op[ [[tan]] ]); pcall(op[ [[\]] ]); end -- Cotangent
+-- Inverse Trigonometry ------------------------------------------------------------------------
 op[ [[asin]] ]  = function() -- Inverse sine
     local x=pop()
     if math.iscomplex(x) then -- i*ln(sqrt(1-x^2)-ix)
@@ -263,16 +253,21 @@ op[ [[acot]] ]  = function() -- Inverse cotangent
     pcall(op[ [[\]] ])
     pcall(op[ [[atan]] ])
 end
+-- Hyperbolic Trigonometry ---------------------------------------------------------------------
 op[ [[sinh]] ]  = function() -- Hyperbolic sine
     local x=pop()
-    if math.iscomplex(x) then push({math.cos(x[2])*math.sinh(x[1]), math.sin(x[2])*math.cosh(x[1])})
-    elseif math.isreal(x) then push(math.sinh(x))
+    if math.iscomplex(x) then
+        push({math.cos(x[2])*math.sinh(x[1]), math.sin(x[2])*math.cosh(x[1])})
+    elseif math.isreal(x) then
+        push(math.sinh(x))
     end
 end
 op[ [[cosh]] ]  = function() -- Hyperbolic cosine
     local x=pop()
-    if math.iscomplex(x) then push({math.cos(x[2])*math.cosh(x[1]), math.sin(x[2])*math.sinh(x[1])})
-    elseif math.isreal(x) then push(math.cosh(x))
+    if math.iscomplex(x) then
+        push({math.cos(x[2])*math.cosh(x[1]), math.sin(x[2])*math.sinh(x[1])})
+    elseif math.isreal(x) then
+        push(math.cosh(x))
     end
 end
 op[ [[tanh]] ]  = function() -- Hyperbolic tangent
@@ -374,9 +369,14 @@ op[ [[acoth]] ] = function() -- Inverse hyperbolic cotangent
     push(2)
     pcall(op[ [[/]] ])
 end
+-- Angle Conversion ----------------------------------------------------------------------------
+op[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
+op[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
 
 
--- Bitwise --------------------------------------------------------------------------------
+-- #############################################################################################
+-- ##################################################################################### Bitwise
+-- #############################################################################################
 op[ [[&]] ]     = function() push(bit.band(pop(),pop())) end -- AND
 op[ [[|]] ]     = function() push(bit.bor(pop(),pop())) end -- OR
 op[ [[^]] ]     = function() push(bit.bxor(pop(),pop())) end -- XOR
@@ -385,14 +385,18 @@ op[ [[<<]] ]    = function() local n=pop(); push(bit.lshift(pop(),n)) end -- Lef
 op[ [[>>]] ]    = function() local n=pop(); push(bit.rshift(pop(),n)) end -- Right Shift
 
 
--- Constants --------------------------------------------------------------------------------
+-- #############################################################################################
+-- ################################################################################### Constants
+-- #############################################################################################
 op[ [[pi]] ]    = function() push(math.pi) end -- 3.141592653....
 op[ [[e]] ]     = function() push(math.exp(1)) end -- 2.718281828...
 op[ [[phi]] ]   = function() push((1+math.sqrt(5)) / 2) end -- 1.618033989...
 op[ [[i]] ]     = function() push({0,1}) end -- the imaginary unit value
 
 
--- Other --------------------------------------------------------------------------------
+-- #############################################################################################
+-- ####################################################################################### Other
+-- #############################################################################################
 op[ [[hrs]] ]   = function() push((pop() / 60 + pop()) / 60 + pop()) end -- Convert Z:Y:X to hours
 op[ [[hms]] ]   = function()  -- Convert X hours to Z:Y:X
     local x=pop()
@@ -403,6 +407,8 @@ op[ [[hms]] ]   = function()  -- Convert X hours to Z:Y:X
     end
     push(x)
 end
+
+
 
 -- Get all unique characters from the op keys. These characters will
 -- trigger completion to begin on this source.

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -129,7 +129,8 @@ op[ [[logx]] ]  = function() local x=pop(); pcall(op[ [[ln]] ]); push(x); pcall(
 op[ [[**]] ] = function() -- Exponentiation - y to the x power
     local x,y = pop(), pop()
     if ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
-        ((math.iscomplex(x) and x[1]==0 and x[2]==0) or x == 0) then push(0/0) -- Use math's NaN, not lua's result of 0^0=1.
+        ((math.iscomplex(x) and x[1]==0 and x[2]==0) or x == 0) then push(0/0)
+        -- Lua says 0^0=1, but use math's convention - undefined (or NaN) - instead.
     elseif math.iscomplex(x) and math.iscomplex(y) then
         local r = math.sqrt(y[1]*y[1] + y[2]*y[2])
         local theta = math.atan2(y[2],y[1])
@@ -407,7 +408,9 @@ op[ [[hms]] ]   = function()  -- Convert X hours to Z:Y:X
     push(x)
 end
 
-
+-- #############################################################################################
+-- ############################################################### End of Operators' Definitions
+-- #############################################################################################
 
 -- Get all unique characters from the op keys. These characters will
 -- trigger completion to begin on this source.

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -277,15 +277,11 @@ op[ [[cosh]] ]  = function() -- Hyperbolic cosine
 end
 op[ [[tanh]] ]  = function() -- Hyperbolic tangent
     local x=pop()
-    if math.iscomplex(x) then
-        push(x)
-        pcall(op[ [[sinh]] ])
-        push(x)
-        pcall(op[ [[cosh]] ])
-        pcall(op[ [[/]] ])
-    elseif math.isreal(x) then
-        push(math.tanh(x))
-    end
+    push(x)
+    pcall(op[ [[sinh]] ])
+    push(x)
+    pcall(op[ [[cosh]] ])
+    pcall(op[ [[/]] ])
 end
 op[ [[csch]] ]  = function() -- Hyperbolic cosecant
     pcall(op[ [[sinh]] ])

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -422,8 +422,8 @@ local function contains(table, val)
 end
 
 local triggerCharacters = vim.fn.split('0123456789.eE', '\\zs')
-for op,_ in pairs(op) do
-    for char in string.gmatch(op, '.') do
+for o,_ in pairs(op) do
+    for char in string.gmatch(o, '.') do
         if not contains(triggerCharacters, char) then
             triggerCharacters[#triggerCharacters+1] = char
         end
@@ -432,12 +432,12 @@ end
 
 -- Create the regex that determines if the text a valid RPN expression.
 local operators = {}
-for op,_ in pairs(op) do
-    operators[#operators+1] = vim.fn.escape(op, [[~^*/\+%|<>&]] )
+for o,_ in pairs(op) do
+    operators[#operators+1] = vim.fn.escape(o, [[~^*/\+%|<>&]] )
 end
 
 local numberRegex = [[[-+]?%(0|0?\.\d+|[1-9]\d*%(\.\d+)?)%([Ee][+-]?\d+)?]]  -- 0, -42, 3.14, 6.02e23, etc.
-local numberRegex = numberRegex .. '%(,' .. numberRegex .. ')?'  -- now they can be complex (an ordered pair)
+numberRegex = numberRegex .. '%(,' .. numberRegex .. ')?'  -- now they can be complex (an ordered pair)
 local operatorsRegex = table.concat(operators,[[|]])  -- Concatenate all operators:  sin|cos|+|-|pi|...
 local wordRegex = [[%(]] .. numberRegex .. [[|]] .. operatorsRegex .. [[)]]  -- A word is a number or an operator.
 local expressionRegex = wordRegex .. [[%( +]] .. wordRegex .. [[)*]]  -- Multiple space-delimited words.

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -113,7 +113,7 @@ end
 -- #############################################################################################
 -- ############################################################################### Powers & Logs
 -- #############################################################################################
-op[ [[log]] ]   = function() -- Natural log of x
+op[ [[ln]] ]   = function() -- Natural log of x
         local x=pop()
     if math.iscomplex(x) then
             local r = math.sqrt(x[1]*x[1] + x[2]*x[2])
@@ -123,9 +123,9 @@ op[ [[log]] ]   = function() -- Natural log of x
             push(math.log(x))
         end
     end
-op[ [[log10]] ] = function() pcall(op[ [[log]] ]); push(10); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 10) of x
-op[ [[log2]] ] = function() pcall(op[ [[log]] ]); push(2); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 2) of x
-op[ [[logx]] ]  = function() local x=pop(); pcall(op[ [[log]] ]); push(x); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log y of x
+op[ [[log]] ] = function() pcall(op[ [[ln]] ]); push(10); pcall(op[ [[ln]] ]); pcall(op[ [[/]] ]) end -- Log (base 10) of x
+op[ [[log2]] ] = function() pcall(op[ [[ln]] ]); push(2); pcall(op[ [[ln]] ]); pcall(op[ [[/]] ]) end -- Log (base 2) of x
+op[ [[logx]] ]  = function() local x=pop(); pcall(op[ [[ln]] ]); push(x); pcall(op[ [[ln]] ]); pcall(op[ [[/]] ]) end -- Log y of x
 op[ [[**]] ] = function() -- Exponentiation - y to the x power
     local x,y = pop(), pop()
     if ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
@@ -204,7 +204,7 @@ op[ [[asin]] ]  = function() -- Inverse sine
         push(x)
         pcall(op[ [[*]] ])
         pcall(op[ [[-]] ])
-        pcall(op[ [[log]] ])
+        pcall(op[ [[ln]] ])
         pcall(op[ [[*]] ])
     else
         push(math.asin(x))
@@ -234,7 +234,7 @@ op[ [[atan]] ]  = function() -- Inverse Tangent
         pcall(op[ [[*]] ])
         pcall(op[ [[-]] ])
         pcall(op[ [[/]] ])
-        pcall(op[ [[log]] ])
+        pcall(op[ [[ln]] ])
         pcall(op[ [[*]] ])
     else
         push(math.atan(x))
@@ -300,7 +300,7 @@ op[ [[asinh]] ] = function() -- Inverse hyperbolic sine
     pcall(op[ [[+]] ])
     pcall(op[ [[sqrt]] ])
     pcall(op[ [[+]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
 end
 op[ [[acosh]] ] = function() -- Inverse hyperbolic cosine
     local x=pop()
@@ -312,7 +312,7 @@ op[ [[acosh]] ] = function() -- Inverse hyperbolic cosine
     pcall(op[ [[-]] ])
     pcall(op[ [[sqrt]] ])
     pcall(op[ [[+]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
 end
 op[ [[atanh]] ] = function() -- Inverse hyperbolic tangent
     local x=pop()
@@ -323,7 +323,7 @@ op[ [[atanh]] ] = function() -- Inverse hyperbolic tangent
     push(x)
     pcall(op[ [[-]] ])
     pcall(op[ [[/]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
     push(2)
     pcall(op[ [[/]] ])
 end
@@ -339,7 +339,7 @@ op[ [[acsch]] ] = function() -- Inverse hyperbolic cosecant
     pcall(op[ [[+]] ])
     push(x)
     pcall(op[ [[/]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
 end
 op[ [[asech]] ] = function() -- Inverse hyperbolic secant
     local x=pop()
@@ -353,7 +353,7 @@ op[ [[asech]] ] = function() -- Inverse hyperbolic secant
     pcall(op[ [[+]] ])
     push(x)
     pcall(op[ [[/]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
 end
 op[ [[acoth]] ] = function() -- Inverse hyperbolic cotangent
     local x=pop()
@@ -364,7 +364,7 @@ op[ [[acoth]] ] = function() -- Inverse hyperbolic cotangent
     push(1)
     pcall(op[ [[-]] ])
     pcall(op[ [[/]] ])
-    pcall(op[ [[log]] ])
+    pcall(op[ [[ln]] ])
     push(2)
     pcall(op[ [[/]] ])
 end

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -9,31 +9,124 @@ local function push(value)
     table.insert(stack, value)
 end
 
+math.isreal = function(x) return type(x) == 'number' end
+math.iscomplex = function(x) return type(x) == 'table' and #x == 2 and type(x[1]) == 'number' and type(x[2]) == 'number' end
+math.round = function(x) return x>=0 and math.floor(x+0.5) or math.ceil(x-0.5) end -- Round to nearest integer
+math.trunc = function(x) return x>=0 and math.floor(x) or math.ceil(x) end -- Round toward zero
+
 local operatorFunc= {}
---[[ Basic Arithmetic ]]
-operatorFunc[ [[+]] ]     = function() push(pop() + pop()) end  -- Addtion
-operatorFunc[ [[-]] ]     = function() push(-pop() + pop()) end -- Subtraction
-operatorFunc[ [[*]] ]     = function() push(pop() * pop()) end  -- Multiplication
-operatorFunc[ [[/]] ]     = function() push(1 / pop()*pop()) end  -- Division
-operatorFunc[ [[div]] ]   = function() local r=1 / pop() * pop(); push(r>=0 and math.floor(r) or math.ceil(r)) end -- Integer part of division
+
+operatorFunc[ [[+]] ] = function()
+        local x=pop(); local y=pop();  -- Addtion
+        if math.isreal(x)        and math.isreal(y)    then push(x + y)
+        elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] + y, x[2]})
+        elseif math.isreal(x)    and math.iscomplex(y) then push({x + y[1], y[2]})
+        elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1] + y[1], x[2] + y[2]})
+        end
+    end
+operatorFunc[ [[-]] ] = function() local x=pop(); local y=pop();  -- Subtraction
+        if math.isreal(x)        and math.isreal(y)    then push(y - x)
+        elseif math.iscomplex(x) and math.isreal(y)    then push({y - x[1], -x[2]})
+        elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] - x, y[2]})
+        elseif math.iscomplex(x) and math.iscomplex(y) then push({y[1] - x[1], y[2] - x[2]})
+        end
+    end
+operatorFunc[ [[*]] ] = function() local x=pop(); local y=pop();  -- Multiplication
+        if math.isreal(x)        and math.isreal(y)    then push(x * y)
+        elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] * y, x[2] * y})
+        elseif math.isreal(x)    and math.iscomplex(y) then push({x * y[1], x * y[2]})
+        elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1]*y[1] - x[2]*y[2], x[1]*y[2] + x[2]*y[1]})
+        end
+    end
+operatorFunc[ [[/]] ] = function() local x=pop(); local y=pop();  -- Division
+        if     math.isreal(x)    and math.isreal(y)    then push(y / x)
+        elseif math.iscomplex(x) and math.isreal(y)    then push({y*x[1]/(x[1]*x[1] + x[2]*x[2]), -y*x[2]/(x[1]*x[1] + x[2]*x[2])})
+        elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] / x, y[2] / x})
+        elseif math.iscomplex(x) and math.iscomplex(y) then push({(y[1]*x[1]+y[2]*x[2]) / (x[1]*x[1]+x[2]*x[2]), (y[2]*x[1]-y[1]*x[2]) / (x[1]*x[1]+x[2]*x[2])})
+        end
+    end
+operatorFunc[ [[div]] ]   = function() local r=1 / pop() * pop(); push(math.trunc(r)) end -- Integer part of division
 operatorFunc[ [[%]] ]     = function() local x=pop(); local y=pop(); push(y % x) end  -- Modulus
-operatorFunc[ [[abs]] ]   = function() push(math.abs(pop())) end  -- Absolute Value
-operatorFunc[ [[chs]] ]   = function() push(-pop()) end  -- Change Sign
---[[ Rounding ]]
-operatorFunc[ [[floor]] ] = function() push(math.floor(pop())) end  -- Floor - round down to nearest integer
-operatorFunc[ [[ceil]] ]  = function() push(math.ceil(pop())) end  -- Ceiling - round up to nearest integer
-operatorFunc[ [[round]] ] = function() local x=pop(); push(x>=0 and math.floor(x+0.5) or math.ceil(x-0.5)) end -- Round to nearest integer
-operatorFunc[ [[trunc]] ] = function() local r=pop(); push(r>=0 and math.floor(r) or math.ceil(r)) end -- Round toward zero
---[[ Powers & Logs ]]
+
+operatorFunc[ [[abs]] ]   = function() local x=pop();  -- Absolute Value
+        if math.isreal(x)        then push(math.abs(x))
+        elseif math.iscomplex(x) then push(math.sqrt(x[1]*x[1] + x[2]*x[2]))
+        end
+    end
+operatorFunc[ [[arg]] ]   = function() local x=pop();  -- Arg
+        if math.isreal(x)        then push('nan')
+        elseif math.iscomplex(x) then push(math.atan2(x[2], x[1]));
+        end
+    end
+
+operatorFunc[ [[chs]] ]   = function() local x=pop();  -- Change Sign
+        if math.isreal(x)        then push(-x)
+        elseif math.iscomplex(x) then push({-x[1], -x[2]})
+        end
+    end
+
+-- Rounding
+operatorFunc[ [[floor]] ] = function() local x = pop();  -- Floor - round down to nearest integer
+        if math.isreal(x)        then push(math.floor(x))
+        elseif math.iscomplex(x) then push({math.floor(x[1]), math.floor(x[2])})
+        end
+    end
+operatorFunc[ [[ceil]] ]  = function() local x = pop();  -- Ceiling - round up to nearest integer
+        if math.isreal(x)        then push(math.ceil(x))
+        elseif math.iscomplex(x) then push({math.ceil(x[1]), math.ceil(x[2])})
+        end
+    end
+operatorFunc[ [[round]] ] = function() local x = pop();  -- Round to nearest integer
+        if math.isreal(x)        then push(math.round(x))
+        elseif math.iscomplex(x) then push({math.round(x[1]), math.round(x[2])})
+        end
+    end
+operatorFunc[ [[trunc]] ] = function() local x = pop();  -- Round toward zero
+        if math.isreal(x)        then push(math.trunc(x))
+        elseif math.iscomplex(x) then push({math.trunc(x[1]), math.trunc(x[2])})
+        end
+    end
+-- Powers & Logs
 operatorFunc[ [[exp]] ]   = function() push(math.exp(pop())) end -- Raise e to the x power
 operatorFunc[ [[log]] ]   = function() push(math.log(pop())) end -- Natural log of x
 operatorFunc[ [[logx]] ]  = function() local x=pop(); push(math.log(pop(),x)) end -- Log y of x
 operatorFunc[ [[log10]] ] = function() push(math.log(pop(),10)) end -- Log (base 10) of x
 operatorFunc[ [[log2]] ]  = function() push(math.log(pop(),2) )end -- Log (base 2) of x
-operatorFunc[ [[sqrt]] ]  = function() push(math.sqrt(pop())) end -- Square Root
-operatorFunc[ [[**]] ]    = function() local x=pop(); local y=pop(); push((y==0 and x==0) and 'nan' or y ^ x) end  -- Exponentiation
+operatorFunc[ [[sqrt]] ]  = function() local x = pop(); -- Square Root
+        if math.isreal(x)        then push(x<0 and {0,math.sqrt(-x)} or math.sqrt(x))
+        elseif math.iscomplex(x) then push({0,0})
+        end
+    end
+operatorFunc[ [[**]] ] = function() local x=pop(); local y=pop(); -- Exponentiation
+        if math.iscomplex(x) and math.iscomplex(y) then
+            local r = math.sqrt(y[1]*y[1] + y[2]*y[2])
+            local theta = math.atan2(y[2],y[1])
+            local m = math.exp(x[1]*math.log(r) - x[2]*theta)
+            push({m*math.cos(x[2]*math.log(r) + x[1]*theta), m*math.sin(x[2]*math.log(r) + x[1]*theta)})
+        elseif math.isreal(x) and math.iscomplex(y) then
+            local r = math.sqrt(y[1]*y[1]+y[2]*y[2])
+            local theta = math.atan2(y[2],y[1])
+            push({math.pow(r,x)*math.cos(theta*x), math.pow(r,x)*math.sin(theta*x)})
+        elseif math.iscomplex(x) then
+            push({math.pow(y,x[1])*math.cos(x[2]*math.log(y)), math.pow(y,x[1])*math.sin(x[2]*math.log(y))})
+        else
+            push((y==0 and x==0) and 'nan' or y ^ x)
+        end
+    end
+
+
+           -- ("**",    [{C,D},{_,_}=Y|S]) -> [R] = rpn("abs",[Y]),
+           --                                 [Theta] = rpn("arg",[Y]),
+           --                                 Multiplier = math:exp(C*math:log(R) - D*Theta),
+           --                                 [{Multiplier*math:cos(D*math:log(R) + C*Theta), Multiplier*math:sin(D*math:log(R) + C*Theta)}|S];
+           -- ("**",    [X,{_,_}=Y    |S]) -> [R] = rpn("abs",[Y]),
+           --                                 [Theta] = rpn("arg",[Y]),
+           --                                 [{math:pow(R,X)*math:cos(Theta*X), math:pow(R,X)*math:sin(Theta*X)}|S];
+           -- ("**",    [{A,B},Y      |S]) -> [{math:pow(Y,A)*math:cos(B*math:log(Y)), math:pow(Y,A)*math:sin(B*math:log(Y))}|S];
+           -- ("**",    [X,Y          |S]) -> [math:pow(Y,X)|S];
+
 operatorFunc[ [[\]] ]     = function() push(1 / pop()) end -- Reciprocal
---[[ Trigonometry ]]
+-- Trigonometry
 operatorFunc[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
 operatorFunc[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
 
@@ -65,21 +158,21 @@ operatorFunc[ [[acsch]] ] = function() local x=pop(); push(math.log((1+math.sqrt
 operatorFunc[ [[asech]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1-x*x)) / x)) end -- Inverse hyperbolic secant
 operatorFunc[ [[acoth]] ] = function() local x=pop(); push(math.log((x+1) / (x-1)) / 2) end -- Inverse hyperbolic cotangent
 
---[[ Bitwise ]]
+-- Bitwise
 operatorFunc[ [[&]] ]     = function() push(bit.band(pop(),pop())) end -- AND
 operatorFunc[ [[|]] ]     = function() push(bit.bor(pop(),pop())) end -- OR
 operatorFunc[ [[^]] ]     = function() push(bit.bxor(pop(),pop())) end -- XOR
 operatorFunc[ [[~]] ]     = function() push(bit.bnot(pop())) end -- NOT
 operatorFunc[ [[<<]] ]    = function() local n=pop(); push(bit.lshift(pop(),n)) end -- Left Shift
 operatorFunc[ [[>>]] ]    = function() local n=pop(); push(bit.rshift(pop(),n)) end -- Right Shift
---[[ Constants ]]
+-- Constants
 operatorFunc[ [[pi]] ]    = function() push(math.pi) end -- 3.141592653....
 operatorFunc[ [[e]] ]     = function() push(math.exp(1)) end -- 2.718281828...
 operatorFunc[ [[phi]] ]   = function() push((1+math.sqrt(5)) / 2) end -- 1.618033989...
---[[ Other ]]
+operatorFunc[ [[i]] ]     = function() push({0,1}) end -- the imaginary unit value
+-- Other
 operatorFunc[ [[hrs]] ]   = function() push((pop() / 60 + pop()) / 60 + pop()) end -- Convert Z:Y:X to hours
 operatorFunc[ [[hms]] ]   = function() local x=pop(); for _=1,2 do local t=x<0 and math.ceil(x) or math.floor(x); push(t); x=60*(x-t); end; push(x) end -- Convert X hours to Z:Y:X
-
 
 -- Get all unique characters from the operatorFunc keys. These characters will
 -- trigger completion to begin on this source.
@@ -92,7 +185,7 @@ local function contains(table, val)
    return false
 end
 
-local triggerCharacters = {' ', '', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', 'E', 'e'}
+local triggerCharacters = vim.fn.split('0123456789.eE', '\\zs')
 for op,_ in pairs(operatorFunc) do
     for char in string.gmatch(op, '.') do
         if not contains(triggerCharacters, char) then
@@ -108,6 +201,7 @@ for op,_ in pairs(operatorFunc) do
 end
 
 local numberRegex = [[[-+]?%(0|0?\.\d+|[1-9]\d*%(\.\d+)?)%([Ee][+-]?\d+)?]]  -- 0, -42, 3.14, 6.02e23, etc.
+local numberRegex = numberRegex .. '%(,' .. numberRegex .. ')?'  -- now they can be complex (an ordered pair)
 local operatorsRegex = table.concat(operators,[[|]])  -- Concatenate all operators:  sin|cos|+|-|pi|...
 local wordRegex = [[%(]] .. numberRegex .. [[|]] .. operatorsRegex .. [[)]]  -- A word is a number or an operator.
 local expressionRegex = wordRegex .. [[%( +]] .. wordRegex .. [[)*]]  -- Multiple space-delimited words.
@@ -134,8 +228,12 @@ source.complete = function(_, request, callback)
     stack = {}
     for _,word in ipairs(vim.fn.split(input, ' \\+')) do
         local number = tonumber(word)
+        -- vim.pretty_print(word)
         if number then
             push(number)
+        elseif word:match('.+,.+') then
+            local c = vim.fn.split(word, ',')
+            push({tonumber(c[1]), tonumber(c[2])})
         else
             local f = operatorFunc[word]
             local ok,_ = pcall(f)
@@ -143,11 +241,17 @@ source.complete = function(_, request, callback)
                 return callback({isIncomplete=true})
             end
         end
+        -- vim.pretty_print(stack)
     end
     local value = ''
     for _,n in ipairs(stack) do
-        value = string.gsub(value .. ' ' .. n, "^%s*(.-)%s*$", "%1")
+        if math.iscomplex(n) then
+            value = value .. ' ' .. n[1] .. (n[2] > 0 and '+' or '') .. n[2] .. 'i'
+        else
+            value = value .. ' ' .. n
+        end
     end
+    value = string.gsub(value, "^%s*(.-)%s*$", "%1")
     input = string.gsub(input, "^%s*(.-)%s*$", "%1")
 
     callback({

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -9,6 +9,7 @@ local function push(value)
     table.insert(stack, value)
 end
 
+-- Extend the math library with some basic functions I'll need below.
 math.isreal = function(x) return type(x) == 'number' end
 math.iscomplex = function(x) return type(x) == 'table' and #x == 2 and type(x[1]) == 'number' and type(x[2]) == 'number' end
 math.round = function(x) return x>=0 and math.floor(x+0.5) or math.ceil(x-0.5) end -- Round to nearest integer
@@ -17,78 +18,98 @@ math.trunc = function(x) return x>=0 and math.floor(x) or math.ceil(x) end -- Ro
 local op= {}
 
 -- Basic Arithmetic --------------------------------------------------------------------------------
-op[ [[+]] ] = function()
-        local x=pop(); local y=pop();  -- Addtion
-        if math.isreal(x)        and math.isreal(y)    then push(x + y)
-        elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] + y, x[2]})
-        elseif math.isreal(x)    and math.iscomplex(y) then push({x + y[1], y[2]})
-        elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1] + y[1], x[2] + y[2]})
-        end
+op[ [[+]] ] = function()  -- Addtion
+    local x,y = pop(), pop()
+    if math.isreal(x)        and math.isreal(y)    then push(x + y)
+    elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] + y, x[2]})
+    elseif math.isreal(x)    and math.iscomplex(y) then push({x + y[1], y[2]})
+    elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1] + y[1], x[2] + y[2]})
     end
-op[ [[-]] ] = function() local x=pop(); local y=pop();  -- Subtraction
-        if math.isreal(x)        and math.isreal(y)    then push(y - x)
-        elseif math.iscomplex(x) and math.isreal(y)    then push({y - x[1], -x[2]})
-        elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] - x, y[2]})
-        elseif math.iscomplex(x) and math.iscomplex(y) then push({y[1] - x[1], y[2] - x[2]})
-        end
+end
+op[ [[-]] ] = function() -- Subtraction
+    local x,y = pop(), pop()
+    if math.isreal(x)        and math.isreal(y)    then push(y - x)
+    elseif math.iscomplex(x) and math.isreal(y)    then push({y - x[1], -x[2]})
+    elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] - x, y[2]})
+    elseif math.iscomplex(x) and math.iscomplex(y) then push({y[1] - x[1], y[2] - x[2]})
     end
-op[ [[*]] ] = function() local x=pop(); local y=pop();  -- Multiplication
-        if math.isreal(x)        and math.isreal(y)    then push(x * y)
-        elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] * y, x[2] * y})
-        elseif math.isreal(x)    and math.iscomplex(y) then push({x * y[1], x * y[2]})
-        elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1]*y[1] - x[2]*y[2], x[1]*y[2] + x[2]*y[1]})
-        end
+end
+op[ [[*]] ] = function() -- Multiplication
+    local x,y = pop(), pop()
+    if math.isreal(x)        and math.isreal(y)    then push(x * y)
+    elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] * y, x[2] * y})
+    elseif math.isreal(x)    and math.iscomplex(y) then push({x * y[1], x * y[2]})
+    elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1]*y[1] - x[2]*y[2], x[1]*y[2] + x[2]*y[1]})
     end
-op[ [[/]] ] = function() local x=pop(); local y=pop();  -- Division
-        if     math.isreal(x)    and math.isreal(y)    then push(y / x)
-        elseif math.iscomplex(x) and math.isreal(y)    then push({y*x[1]/(x[1]*x[1] + x[2]*x[2]), -y*x[2]/(x[1]*x[1] + x[2]*x[2])})
-        elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] / x, y[2] / x})
-        elseif math.iscomplex(x) and math.iscomplex(y) then push({(y[1]*x[1]+y[2]*x[2]) / (x[1]*x[1]+x[2]*x[2]), (y[2]*x[1]-y[1]*x[2]) / (x[1]*x[1]+x[2]*x[2])})
-        end
+end
+op[ [[/]] ] = function() -- Division
+    local x,y = pop(), pop()
+    if     math.isreal(x)    and math.isreal(y)    then push(y / x)
+    elseif math.iscomplex(x) and math.isreal(y)    then push({y*x[1]/(x[1]*x[1] + x[2]*x[2]), -y*x[2]/(x[1]*x[1] + x[2]*x[2])})
+    elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] / x, y[2] / x})
+    elseif math.iscomplex(x) and math.iscomplex(y) then push({(y[1]*x[1]+y[2]*x[2]) / (x[1]*x[1]+x[2]*x[2]), (y[2]*x[1]-y[1]*x[2]) / (x[1]*x[1]+x[2]*x[2])})
     end
-op[ [[div]] ]   = function() local r=1 / pop() * pop(); push(math.trunc(r)) end -- Integer part of division
-op[ [[%]] ]     = function() local x=pop(); local y=pop(); push(y % x) end  -- Modulus
-op[ [[abs]] ]   = function() local x=pop();  -- Absolute Value
-        if math.isreal(x)        then push(math.abs(x))
-        elseif math.iscomplex(x) then push(math.sqrt(x[1]*x[1] + x[2]*x[2]))
-        end
+end
+op[ [[div]] ]   = function()  -- Integer part of division
+    local x,y = pop(), pop()
+    push(math.trunc(y / x))
+end
+op[ [[%]] ]     = function()  -- Modulus
+    local x,y = pop(), pop()
+    push(y % x)
+end
+op[ [[abs]] ]   = function() -- Absolute Value
+    local x=pop()
+    if math.isreal(x)        then push(math.abs(x))
+    elseif math.iscomplex(x) then push(math.sqrt(x[1]*x[1] + x[2]*x[2]))
     end
-op[ [[arg]] ]   = function() local x=pop();  -- Arg
-        if math.isreal(x)        then push('nan')
-        elseif math.iscomplex(x) then push(math.atan2(x[2], x[1]));
-        end
+end
+op[ [[arg]] ]   = function() -- Arg
+    local x=pop()
+    if math.isreal(x)        then push('nan')
+    elseif math.iscomplex(x) then push(math.atan2(x[2], x[1]));
     end
-op[ [[chs]] ]   = function() local x=pop();  -- Change Sign
-        if math.isreal(x)        then push(-x)
-        elseif math.iscomplex(x) then push({-x[1], -x[2]})
-        end
+end
+op[ [[chs]] ]   = function() -- Change Sign
+    local x=pop()
+    if math.isreal(x)        then push(-x)
+    elseif math.iscomplex(x) then push({-x[1], -x[2]})
     end
+end
+
 
 -- Rounding --------------------------------------------------------------------------------
-op[ [[floor]] ] = function() local x = pop();  -- Floor - round down to nearest integer
-        if math.isreal(x)        then push(math.floor(x))
-        elseif math.iscomplex(x) then push({math.floor(x[1]), math.floor(x[2])})
-        end
+op[ [[floor]] ] = function() -- Floor - round down to nearest integer
+    local x=pop()
+    if math.isreal(x)        then push(math.floor(x))
+    elseif math.iscomplex(x) then push({math.floor(x[1]), math.floor(x[2])})
     end
-op[ [[ceil]] ]  = function() local x = pop();  -- Ceiling - round up to nearest integer
-        if math.isreal(x)        then push(math.ceil(x))
-        elseif math.iscomplex(x) then push({math.ceil(x[1]), math.ceil(x[2])})
-        end
+end
+op[ [[ceil]] ]  = function() -- Ceiling - round up to nearest integer
+    local x=pop()
+    if math.isreal(x)        then push(math.ceil(x))
+    elseif math.iscomplex(x) then push({math.ceil(x[1]), math.ceil(x[2])})
     end
-op[ [[round]] ] = function() local x = pop();  -- Round to nearest integer
-        if math.isreal(x)        then push(math.round(x))
-        elseif math.iscomplex(x) then push({math.round(x[1]), math.round(x[2])})
-        end
+end
+op[ [[round]] ] = function() -- Round to nearest integer
+    local x=pop()
+    if math.isreal(x)        then push(math.round(x))
+    elseif math.iscomplex(x) then push({math.round(x[1]), math.round(x[2])})
     end
-op[ [[trunc]] ] = function() local x = pop();  -- Round toward zero
-        if math.isreal(x)        then push(math.trunc(x))
-        elseif math.iscomplex(x) then push({math.trunc(x[1]), math.trunc(x[2])})
-        end
+end
+op[ [[trunc]] ] = function() -- Round toward zero
+    local x=pop()
+    if math.isreal(x)        then push(math.trunc(x))
+    elseif math.iscomplex(x) then push({math.trunc(x[1]), math.trunc(x[2])})
     end
+end
+
 
 -- Powers & Logs --------------------------------------------------------------------------------
-op[ [[log]] ]   = function() local x = pop(); -- Natural log of x
-        if math.iscomplex(x) then
+-- ln(a+bi)   =   ln(re^it)  =  ln(r)+ln(e^it)  =  ln(r)+it
+op[ [[log]] ]   = function() -- Natural log of x
+        local x=pop()
+    if math.iscomplex(x) then
             local r = math.sqrt(x[1]*x[1] + x[2]*x[2])
             local theta = math.atan2(x[2],x[1])
             push({math.log(r), theta})
@@ -99,39 +120,45 @@ op[ [[log]] ]   = function() local x = pop(); -- Natural log of x
 op[ [[log10]] ] = function() pcall(op[ [[log]] ]); push(10); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 10) of x
 op[ [[log2]] ] = function() pcall(op[ [[log]] ]); push(2); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 2) of x
 op[ [[logx]] ]  = function() local x=pop(); pcall(op[ [[log]] ]); push(x); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log y of x
-
-op[ [[**]] ] = function() local x=pop(); local y=pop(); -- Exponentiation - y to the x power
-        if ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
-           ((math.iscomplex(x) and x[1]==0 and x[2]==0) or x == 0) then push('nan')
-        elseif ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
-               (math.isreal(x) and x < 0) then push('inf')
-        elseif math.iscomplex(x) and math.iscomplex(y) then
-            local r = math.sqrt(y[1]*y[1] + y[2]*y[2])
-            local theta = math.atan2(y[2],y[1])
-            local m = math.exp(x[1]*math.log(r) - x[2]*theta)
-            push({m*math.cos(x[2]*math.log(r) + x[1]*theta), m*math.sin(x[2]*math.log(r) + x[1]*theta)})
-        elseif math.isreal(x) and math.iscomplex(y) then
-            local r = math.sqrt(y[1]*y[1]+y[2]*y[2])
-            local theta = math.atan2(y[2],y[1])
-            push({math.pow(r,x)*math.cos(theta*x), math.pow(r,x)*math.sin(theta*x)})
-        elseif math.iscomplex(x) then
-            push({math.pow(y,x[1])*math.cos(x[2]*math.log(y)), math.pow(y,x[1])*math.sin(x[2]*math.log(y))})
-        elseif y < 0 and x ~= math.round(x) then
-            push({y,0})
-            push(x)
-            pcall(op[ [[**]] ])
-        else
-            push(y ^ x)
-        end
+op[ [[**]] ] = function() -- Exponentiation - y to the x power
+    local x,y = pop(), pop()
+    if ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
+        ((math.iscomplex(x) and x[1]==0 and x[2]==0) or x == 0) then push('nan')
+    elseif ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
+        (math.isreal(x) and x < 0) then push('inf')
+    elseif math.iscomplex(x) and math.iscomplex(y) then
+        local r = math.sqrt(y[1]*y[1] + y[2]*y[2])
+        local theta = math.atan2(y[2],y[1])
+        local m = math.exp(x[1]*math.log(r) - x[2]*theta)
+        push({m*math.cos(x[2]*math.log(r) + x[1]*theta), m*math.sin(x[2]*math.log(r) + x[1]*theta)})
+    elseif math.isreal(x) and math.iscomplex(y) then
+        local r = math.sqrt(y[1]*y[1]+y[2]*y[2])
+        local theta = math.atan2(y[2],y[1])
+        push({math.pow(r,x)*math.cos(theta*x), math.pow(r,x)*math.sin(theta*x)})
+    elseif math.iscomplex(x) then
+        push({math.pow(y,x[1])*math.cos(x[2]*math.log(y)), math.pow(y,x[1])*math.sin(x[2]*math.log(y))})
+    elseif y < 0 and x ~= math.round(x) then
+        push({y,0})
+        push(x)
+        pcall(op[ [[**]] ])
+    else
+        push(y ^ x)
     end
-op[ [[exp]] ]   = function() local x = pop(); push(math.exp(1)); push(x); pcall(op[ [[**]] ]) end -- Raise e to the x power
+end
+op[ [[exp]] ]   = function()
+    local x=pop()
+    push(math.exp(1))
+    push(x)
+    pcall(op[ [[**]] ])
+end -- Raise e to the x power
 op[ [[\]] ]     = function() push(-1); pcall(op[ [[**]] ]) end -- Reciprocal
 op[ [[sqrt]] ]  = function() push(0.5); pcall(op[ [[**]] ]) end -- Square root of x
+
 
 -- Trigonometry --------------------------------------------------------------------------------
 op[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
 op[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
-
+--
 -- Using these identities, we can calculate trig values of complex numbers:
 --    sin(z) = (e^iz - e^-iz) / 2i         cos(z) = (e^iz + e^-iz) / 2
 --    sin(iz) = (e^iiz - e^-iiz) / 2i      cos(iz) = (e^iiz + e^-iiz) / 2
@@ -140,77 +167,145 @@ op[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
 --
 -- sin(a+bi) = sin(a)*cos(bi) + cos(a)*sin(bi)*i   =   sin(a)*cosh(b) + cos(a)*sinh(b)*i
 -- cos(a+bi) = cos(z)*cos(bi) - sin(a)*sin(bi)*i   =   cos(a)*cosh(b) - sin(a)*sinh(b)*i
-
+--
 -- sinh(a+bi) = -i*sin(ia+ibi) = -i*sin(-b+ai) = -i*(sin(-b)*cosh(a) + cos(-b)*sinh(a)*i) =  cos(b)*sinh(a) + sin(b)*cosh(a)*i
 -- cosh(a+bi) = cos(ia+ibi)    = cos(-b+ai)    = cos(-b)*cosh(a) - sin(-b)*sinh(a)*i =   cos(b)*cosh(a) + sin(b)*sinh(a)*i
-
+--
 -- Then, as usual, tan = sin / cos,      csc = 1 / sin,     sec = 1 / cos,     cot = 1 / tan
 --                 tanh = sinh / cosh,   csch = 1 / sinh,   sech = 1 / cosh,   coth = 1 / tanh
-
-op[ [[sin]] ]   = function() local x = pop(); -- Sine
-        if math.iscomplex(x) then
-            push({math.sin(x[1])*math.cosh(x[2]), math.cos(x[1])*math.sinh(x[2])})
-        elseif math.isreal(x) then push(math.sin(x))
-        end
+--
+op[ [[sin]] ]   = function() -- Sine
+    local x=pop()
+    if math.iscomplex(x) then
+        push({math.sin(x[1])*math.cosh(x[2]), math.cos(x[1])*math.sinh(x[2])})
+    elseif math.isreal(x) then push(math.sin(x))
     end
-op[ [[cos]] ]   = function() local x = pop(); -- Cosine
-        if math.iscomplex(x) then push({math.cos(x[1])*math.cosh(x[2]), -math.sin(x[1])*math.sinh(x[2])})
-        elseif math.isreal(x) then push(math.cos(x))
-        end
+end
+op[ [[cos]] ]   = function() -- Cosine
+    local x=pop()
+    if math.iscomplex(x) then push({math.cos(x[1])*math.cosh(x[2]), -math.sin(x[1])*math.sinh(x[2])})
+    elseif math.isreal(x) then push(math.cos(x))
     end
-op[ [[tan]] ]   = function() local x = pop(); -- Tangent
-        if math.iscomplex(x) then
-            push(x)
-            pcall(op[ [[sin]] ])
-            push(x)
-            pcall(op[ [[cos]] ])
-            pcall(op[ [[/]] ])
-        elseif math.isreal(x) then push(math.tan(x))
-        end
+end
+op[ [[tan]] ]   = function() -- Tangent
+    local x=pop()
+    if math.iscomplex(x) then
+        push(x)
+        pcall(op[ [[sin]] ])
+        push(x)
+        pcall(op[ [[cos]] ])
+        pcall(op[ [[/]] ])
+    elseif math.isreal(x) then push(math.tan(x))
     end
+end
 op[ [[csc]] ]   = function() pcall(op[ [[sin]] ]); pcall(op[ [[\]] ]); end -- Cosecant
 op[ [[sec]] ]   = function() pcall(op[ [[cos]] ]); pcall(op[ [[\]] ]); end -- Secant
 op[ [[cot]] ]   = function() pcall(op[ [[tan]] ]); pcall(op[ [[\]] ]); end -- Cotangent
-
-op[ [[asin]] ]  = function() push(math.asin(pop())) end -- Inverse sine
-op[ [[acos]] ]  = function() push(math.acos(pop())) end -- Inverse cosine
-op[ [[atan]] ]  = function() push(math.atan(pop())) end -- Inverse Tangent
-op[ [[acsc]] ]  = function() push(math.asin(1 / pop())) end -- Inverse cosecant
-op[ [[asec]] ]  = function() push(math.acos(1 / pop())) end -- Inverse secant
-op[ [[acot]] ]  = function() push(math.atan(1 / pop())) end -- Inverse cotangent
-
-op[ [[sinh]] ]  = function() local x=pop(); -- Hyperbolic sine
-        if math.iscomplex(x) then push({math.cos(x[2])*math.sinh(x[1]), math.sin(x[2])*math.cosh(x[1])})
-        elseif math.isreal(x) then push(math.sinh(x))
-        end
+op[ [[asin]] ]  = function() -- Inverse sine
+    local x=pop()
+    if math.iscomplex(x) then -- i*ln(sqrt(1-x^2)-ix)
+        push({0,1})
+        push(1)
+        push(x)
+        push(2)
+        pcall(op[ [[**]] ])
+        pcall(op[ [[-]] ])
+        pcall(op[ [[sqrt]] ])
+        push({0,1})
+        push(x)
+        pcall(op[ [[*]] ])
+        pcall(op[ [[-]] ])
+        pcall(op[ [[log]] ])
+        pcall(op[ [[*]] ])
+    else
+        push(math.asin(x))
     end
-op[ [[cosh]] ]  = function() local x=pop(); -- Hyperbolic cosine
-        if math.iscomplex(x) then push({math.cos(x[2])*math.cosh(x[1]), math.sin(x[2])*math.sinh(x[1])})
-        elseif math.isreal(x) then push(math.cosh(x))
-        end
+end
+op[ [[acos]] ]  = function() -- Inverse cosine = pi/2 - asin(x)
+    local x=pop()
+    pcall(op[ [[pi]] ])
+    push(2)
+    pcall(op[ [[/]] ])
+    push(x)
+    pcall(op[ [[asin]] ])
+    pcall(op[ [[-]] ])
+end
+op[ [[atan]] ]  = function() -- Inverse Tangent
+    local x=pop()
+    if math.iscomplex(x) then -- -i/2*ln((1+ix)/(1-ix))
+        push({0,-0.5})
+        push(1)
+        push({0,1})
+        push(x)
+        pcall(op[ [[*]] ])
+        pcall(op[ [[+]] ])
+        push(1)
+        push({0,1})
+        push(x)
+        pcall(op[ [[*]] ])
+        pcall(op[ [[-]] ])
+        pcall(op[ [[/]] ])
+        pcall(op[ [[log]] ])
+        pcall(op[ [[*]] ])
+    else
+        push(math.atan(x))
     end
-op[ [[tanh]] ]  = function() local x=pop(); -- Hyperbolic tangent
-        if math.iscomplex(x) then
-            push(x)
-            pcall(op[ [[sinh]] ])
-            push(x)
-            pcall(op[ [[cosh]] ])
-            pcall(op[ [[/]] ])
-        elseif math.isreal(x) then
-    push(math.tanh(x))
-        end
+end
+op[ [[acsc]] ]  = function() -- Inverse cosecant
+    pcall(op[ [[\]] ])
+    pcall(op[ [[asin]] ])
+end
+op[ [[asec]] ]  = function() -- Inverse secant
+    pcall(op[ [[\]] ])
+    pcall(op[ [[acos]] ])
+end
+op[ [[acot]] ]  = function() -- Inverse cotangent
+    pcall(op[ [[\]] ])
+    pcall(op[ [[atan]] ])
+end
+op[ [[sinh]] ]  = function() -- Hyperbolic sine
+    local x=pop()
+    if math.iscomplex(x) then push({math.cos(x[2])*math.sinh(x[1]), math.sin(x[2])*math.cosh(x[1])})
+    elseif math.isreal(x) then push(math.sinh(x))
     end
-op[ [[csch]] ]  = function() pcall(op[ [[sinh]] ]); pcall(op[ [[\]] ]); end -- Hyperbolic cosecant
-op[ [[sech]] ]  = function() pcall(op[ [[cosh]] ]); pcall(op[ [[\]] ]); end -- Hyperbolic secant
-op[ [[coth]] ]  = function() pcall(op[ [[tanh]] ]); pcall(op[ [[\]] ]); end -- Hyperbolic cotangent
-
+end
+op[ [[cosh]] ]  = function() -- Hyperbolic cosine
+    local x=pop()
+    if math.iscomplex(x) then push({math.cos(x[2])*math.cosh(x[1]), math.sin(x[2])*math.sinh(x[1])})
+    elseif math.isreal(x) then push(math.cosh(x))
+    end
+end
+op[ [[tanh]] ]  = function() -- Hyperbolic tangent
+    local x=pop()
+    if math.iscomplex(x) then
+        push(x)
+        pcall(op[ [[sinh]] ])
+        push(x)
+        pcall(op[ [[cosh]] ])
+        pcall(op[ [[/]] ])
+    elseif math.isreal(x) then
+        push(math.tanh(x))
+    end
+end
+op[ [[csch]] ]  = function() -- Hyperbolic cosecant
+    pcall(op[ [[sinh]] ])
+    pcall(op[ [[\]] ])
+end
+op[ [[sech]] ]  = function() -- Hyperbolic secant
+    pcall(op[ [[cosh]] ])
+    pcall(op[ [[\]] ])
+end
+op[ [[coth]] ]  = function() -- Hyperbolic cotangent
+    pcall(op[ [[tanh]] ])
+    pcall(op[ [[\]] ])
+end
 op[ [[asinh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x+1))) end -- Inverse hyperbolic sine
 op[ [[acosh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x-1))) end -- Inverse hyperbolic cosine
 op[ [[atanh]] ] = function() local x=pop(); push(math.log((1+x) / (1-x)) / 2) end -- Inverse hyperbolic tangent
-
 op[ [[acsch]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1+x*x)) / x)) end -- Inverse hyperbolic cosecant
 op[ [[asech]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1-x*x)) / x)) end -- Inverse hyperbolic secant
 op[ [[acoth]] ] = function() local x=pop(); push(math.log((x+1) / (x-1)) / 2) end -- Inverse hyperbolic cotangent
+
 
 -- Bitwise --------------------------------------------------------------------------------
 op[ [[&]] ]     = function() push(bit.band(pop(),pop())) end -- AND
@@ -220,15 +315,25 @@ op[ [[~]] ]     = function() push(bit.bnot(pop())) end -- NOT
 op[ [[<<]] ]    = function() local n=pop(); push(bit.lshift(pop(),n)) end -- Left Shift
 op[ [[>>]] ]    = function() local n=pop(); push(bit.rshift(pop(),n)) end -- Right Shift
 
+
 -- Constants --------------------------------------------------------------------------------
 op[ [[pi]] ]    = function() push(math.pi) end -- 3.141592653....
 op[ [[e]] ]     = function() push(math.exp(1)) end -- 2.718281828...
 op[ [[phi]] ]   = function() push((1+math.sqrt(5)) / 2) end -- 1.618033989...
 op[ [[i]] ]     = function() push({0,1}) end -- the imaginary unit value
 
+
 -- Other --------------------------------------------------------------------------------
 op[ [[hrs]] ]   = function() push((pop() / 60 + pop()) / 60 + pop()) end -- Convert Z:Y:X to hours
-op[ [[hms]] ]   = function() local x=pop(); for _=1,2 do local t=x<0 and math.ceil(x) or math.floor(x); push(t); x=60*(x-t); end; push(x) end -- Convert X hours to Z:Y:X
+op[ [[hms]] ]   = function()  -- Convert X hours to Z:Y:X
+    local x=pop()
+    for _=1,2 do
+        local t=x<0 and math.ceil(x) or math.floor(x)
+        push(t)
+        x=60*(x-t)
+    end
+    push(x)
+end
 
 -- Get all unique characters from the op keys. These characters will
 -- trigger completion to begin on this source.

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -457,7 +457,7 @@ source.complete = function(_, request, callback)
     local input = request.context.cursor_before_line
     local s,e = vim.regex(expressionRegex):match_str(input)
     if not s or not e then
-        return callback({isIncomplete=true})
+        return callback({})
     end
     input = string.sub(input, s+1)
 
@@ -474,7 +474,7 @@ source.complete = function(_, request, callback)
             local f = op[word]
             local ok,_ = pcall(f)
             if not ok then
-                return callback({isIncomplete=true})
+                return callback({})
             end
         end
         -- vim.pretty_print(stack)

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -68,7 +68,7 @@ op[ [[abs]] ]   = function() -- Absolute Value
 end
 op[ [[arg]] ]   = function() -- Arg
     local x=pop()
-    if math.isreal(x)        then push('nan')
+    if math.isreal(x)        then push(x < 0 and math.pi or 0)
     elseif math.iscomplex(x) then push(math.atan2(x[2], x[1]));
     end
 end

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -14,9 +14,10 @@ math.iscomplex = function(x) return type(x) == 'table' and #x == 2 and type(x[1]
 math.round = function(x) return x>=0 and math.floor(x+0.5) or math.ceil(x-0.5) end -- Round to nearest integer
 math.trunc = function(x) return x>=0 and math.floor(x) or math.ceil(x) end -- Round toward zero
 
-local operatorFunc= {}
+local op= {}
 
-operatorFunc[ [[+]] ] = function()
+-- Basic Arithmetic --------------------------------------------------------------------------------
+op[ [[+]] ] = function()
         local x=pop(); local y=pop();  -- Addtion
         if math.isreal(x)        and math.isreal(y)    then push(x + y)
         elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] + y, x[2]})
@@ -24,81 +25,87 @@ operatorFunc[ [[+]] ] = function()
         elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1] + y[1], x[2] + y[2]})
         end
     end
-operatorFunc[ [[-]] ] = function() local x=pop(); local y=pop();  -- Subtraction
+op[ [[-]] ] = function() local x=pop(); local y=pop();  -- Subtraction
         if math.isreal(x)        and math.isreal(y)    then push(y - x)
         elseif math.iscomplex(x) and math.isreal(y)    then push({y - x[1], -x[2]})
         elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] - x, y[2]})
         elseif math.iscomplex(x) and math.iscomplex(y) then push({y[1] - x[1], y[2] - x[2]})
         end
     end
-operatorFunc[ [[*]] ] = function() local x=pop(); local y=pop();  -- Multiplication
+op[ [[*]] ] = function() local x=pop(); local y=pop();  -- Multiplication
         if math.isreal(x)        and math.isreal(y)    then push(x * y)
         elseif math.iscomplex(x) and math.isreal(y)    then push({x[1] * y, x[2] * y})
         elseif math.isreal(x)    and math.iscomplex(y) then push({x * y[1], x * y[2]})
         elseif math.iscomplex(x) and math.iscomplex(y) then push({x[1]*y[1] - x[2]*y[2], x[1]*y[2] + x[2]*y[1]})
         end
     end
-operatorFunc[ [[/]] ] = function() local x=pop(); local y=pop();  -- Division
+op[ [[/]] ] = function() local x=pop(); local y=pop();  -- Division
         if     math.isreal(x)    and math.isreal(y)    then push(y / x)
         elseif math.iscomplex(x) and math.isreal(y)    then push({y*x[1]/(x[1]*x[1] + x[2]*x[2]), -y*x[2]/(x[1]*x[1] + x[2]*x[2])})
         elseif math.isreal(x)    and math.iscomplex(y) then push({y[1] / x, y[2] / x})
         elseif math.iscomplex(x) and math.iscomplex(y) then push({(y[1]*x[1]+y[2]*x[2]) / (x[1]*x[1]+x[2]*x[2]), (y[2]*x[1]-y[1]*x[2]) / (x[1]*x[1]+x[2]*x[2])})
         end
     end
-operatorFunc[ [[div]] ]   = function() local r=1 / pop() * pop(); push(math.trunc(r)) end -- Integer part of division
-operatorFunc[ [[%]] ]     = function() local x=pop(); local y=pop(); push(y % x) end  -- Modulus
-
-operatorFunc[ [[abs]] ]   = function() local x=pop();  -- Absolute Value
+op[ [[div]] ]   = function() local r=1 / pop() * pop(); push(math.trunc(r)) end -- Integer part of division
+op[ [[%]] ]     = function() local x=pop(); local y=pop(); push(y % x) end  -- Modulus
+op[ [[abs]] ]   = function() local x=pop();  -- Absolute Value
         if math.isreal(x)        then push(math.abs(x))
         elseif math.iscomplex(x) then push(math.sqrt(x[1]*x[1] + x[2]*x[2]))
         end
     end
-operatorFunc[ [[arg]] ]   = function() local x=pop();  -- Arg
+op[ [[arg]] ]   = function() local x=pop();  -- Arg
         if math.isreal(x)        then push('nan')
         elseif math.iscomplex(x) then push(math.atan2(x[2], x[1]));
         end
     end
-
-operatorFunc[ [[chs]] ]   = function() local x=pop();  -- Change Sign
+op[ [[chs]] ]   = function() local x=pop();  -- Change Sign
         if math.isreal(x)        then push(-x)
         elseif math.iscomplex(x) then push({-x[1], -x[2]})
         end
     end
 
--- Rounding
-operatorFunc[ [[floor]] ] = function() local x = pop();  -- Floor - round down to nearest integer
+-- Rounding --------------------------------------------------------------------------------
+op[ [[floor]] ] = function() local x = pop();  -- Floor - round down to nearest integer
         if math.isreal(x)        then push(math.floor(x))
         elseif math.iscomplex(x) then push({math.floor(x[1]), math.floor(x[2])})
         end
     end
-operatorFunc[ [[ceil]] ]  = function() local x = pop();  -- Ceiling - round up to nearest integer
+op[ [[ceil]] ]  = function() local x = pop();  -- Ceiling - round up to nearest integer
         if math.isreal(x)        then push(math.ceil(x))
         elseif math.iscomplex(x) then push({math.ceil(x[1]), math.ceil(x[2])})
         end
     end
-operatorFunc[ [[round]] ] = function() local x = pop();  -- Round to nearest integer
+op[ [[round]] ] = function() local x = pop();  -- Round to nearest integer
         if math.isreal(x)        then push(math.round(x))
         elseif math.iscomplex(x) then push({math.round(x[1]), math.round(x[2])})
         end
     end
-operatorFunc[ [[trunc]] ] = function() local x = pop();  -- Round toward zero
+op[ [[trunc]] ] = function() local x = pop();  -- Round toward zero
         if math.isreal(x)        then push(math.trunc(x))
         elseif math.iscomplex(x) then push({math.trunc(x[1]), math.trunc(x[2])})
         end
     end
--- Powers & Logs
-operatorFunc[ [[exp]] ]   = function() push(math.exp(pop())) end -- Raise e to the x power
-operatorFunc[ [[log]] ]   = function() push(math.log(pop())) end -- Natural log of x
-operatorFunc[ [[logx]] ]  = function() local x=pop(); push(math.log(pop(),x)) end -- Log y of x
-operatorFunc[ [[log10]] ] = function() push(math.log(pop(),10)) end -- Log (base 10) of x
-operatorFunc[ [[log2]] ]  = function() push(math.log(pop(),2) )end -- Log (base 2) of x
-operatorFunc[ [[sqrt]] ]  = function() local x = pop(); -- Square Root
-        if math.isreal(x)        then push(x<0 and {0,math.sqrt(-x)} or math.sqrt(x))
-        elseif math.iscomplex(x) then push({0,0})
+
+-- Powers & Logs --------------------------------------------------------------------------------
+op[ [[log]] ]   = function() local x = pop(); -- Natural log of x
+        if math.iscomplex(x) then
+            local r = math.sqrt(x[1]*x[1] + x[2]*x[2])
+            local theta = math.atan2(x[2],x[1])
+            push({math.log(r), theta})
+        elseif math.isreal(x) then
+            push(math.log(x))
         end
     end
-operatorFunc[ [[**]] ] = function() local x=pop(); local y=pop(); -- Exponentiation
-        if math.iscomplex(x) and math.iscomplex(y) then
+op[ [[log10]] ] = function() pcall(op[ [[log]] ]); push(10); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 10) of x
+op[ [[log2]] ] = function() pcall(op[ [[log]] ]); push(2); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log (base 2) of x
+op[ [[logx]] ]  = function() local x=pop(); pcall(op[ [[log]] ]); push(x); pcall(op[ [[log]] ]); pcall(op[ [[/]] ]) end -- Log y of x
+
+op[ [[**]] ] = function() local x=pop(); local y=pop(); -- Exponentiation - y to the x power
+        if ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
+           ((math.iscomplex(x) and x[1]==0 and x[2]==0) or x == 0) then push('nan')
+        elseif ((math.iscomplex(y) and y[1]==0 and y[2]==0) or y == 0) and
+               (math.isreal(x) and x < 0) then push('inf')
+        elseif math.iscomplex(x) and math.iscomplex(y) then
             local r = math.sqrt(y[1]*y[1] + y[2]*y[2])
             local theta = math.atan2(y[2],y[1])
             local m = math.exp(x[1]*math.log(r) - x[2]*theta)
@@ -109,72 +116,69 @@ operatorFunc[ [[**]] ] = function() local x=pop(); local y=pop(); -- Exponentiat
             push({math.pow(r,x)*math.cos(theta*x), math.pow(r,x)*math.sin(theta*x)})
         elseif math.iscomplex(x) then
             push({math.pow(y,x[1])*math.cos(x[2]*math.log(y)), math.pow(y,x[1])*math.sin(x[2]*math.log(y))})
+        elseif y < 0 and x ~= math.round(x) then
+            push({y,0})
+            push(x)
+            pcall(op[ [[**]] ])
         else
-            push((y==0 and x==0) and 'nan' or y ^ x)
+            push(y ^ x)
         end
     end
+op[ [[exp]] ]   = function() local x = pop(); push(math.exp(1)); push(x); pcall(op[ [[**]] ]) end -- Raise e to the x power
+op[ [[\]] ]     = function() push(-1); pcall(op[ [[**]] ]) end -- Reciprocal
+op[ [[sqrt]] ]  = function() push(0.5); pcall(op[ [[**]] ]) end -- Square root of x
 
+-- Trigonometry --------------------------------------------------------------------------------
+op[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
+op[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
 
-           -- ("**",    [{C,D},{_,_}=Y|S]) -> [R] = rpn("abs",[Y]),
-           --                                 [Theta] = rpn("arg",[Y]),
-           --                                 Multiplier = math:exp(C*math:log(R) - D*Theta),
-           --                                 [{Multiplier*math:cos(D*math:log(R) + C*Theta), Multiplier*math:sin(D*math:log(R) + C*Theta)}|S];
-           -- ("**",    [X,{_,_}=Y    |S]) -> [R] = rpn("abs",[Y]),
-           --                                 [Theta] = rpn("arg",[Y]),
-           --                                 [{math:pow(R,X)*math:cos(Theta*X), math:pow(R,X)*math:sin(Theta*X)}|S];
-           -- ("**",    [{A,B},Y      |S]) -> [{math:pow(Y,A)*math:cos(B*math:log(Y)), math:pow(Y,A)*math:sin(B*math:log(Y))}|S];
-           -- ("**",    [X,Y          |S]) -> [math:pow(Y,X)|S];
+op[ [[sin]] ]   = function() push(math.sin(pop())) end -- Sine
+op[ [[cos]] ]   = function() push(math.cos(pop())) end -- Cosine
+op[ [[tan]] ]   = function() push(math.tan(pop())) end -- Tangent
+op[ [[csc]] ]   = function() push(1 / math.sin(pop())) end -- Cosecant
+op[ [[sec]] ]   = function() push(1 / math.cos(pop())) end -- Secant
+op[ [[cot]] ]   = function() push(1 / math.tan(pop())) end -- Cotangent
 
-operatorFunc[ [[\]] ]     = function() push(1 / pop()) end -- Reciprocal
--- Trigonometry
-operatorFunc[ [[deg]] ]   = function() push(math.deg(pop())) end -- convert x to degrees
-operatorFunc[ [[rad]] ]   = function() push(math.rad(pop())) end -- convert x to radians
+op[ [[asin]] ]  = function() push(math.asin(pop())) end -- Inverse sine
+op[ [[acos]] ]  = function() push(math.acos(pop())) end -- Inverse cosine
+op[ [[atan]] ]  = function() push(math.atan(pop())) end -- Inverse Tangent
+op[ [[acsc]] ]  = function() push(math.asin(1 / pop())) end -- Inverse cosecant
+op[ [[asec]] ]  = function() push(math.acos(1 / pop())) end -- Inverse secant
+op[ [[acot]] ]  = function() push(math.atan(1 / pop())) end -- Inverse cotangent
 
-operatorFunc[ [[sin]] ]   = function() push(math.sin(pop())) end -- Sine
-operatorFunc[ [[cos]] ]   = function() push(math.cos(pop())) end -- Cosine
-operatorFunc[ [[tan]] ]   = function() push(math.tan(pop())) end -- Tangent
-operatorFunc[ [[csc]] ]   = function() push(1 / math.sin(pop())) end -- Cosecant
-operatorFunc[ [[sec]] ]   = function() push(1 / math.cos(pop())) end -- Secant
-operatorFunc[ [[cot]] ]   = function() push(1 / math.tan(pop())) end -- Cotangent
+op[ [[sinh]] ]  = function() local x=pop(); push((math.exp(x) - math.exp(-x)) / 2) end -- Hyperbolic sine
+op[ [[cosh]] ]  = function() local x=pop(); push((math.exp(x) + math.exp(-x)) / 2) end -- Hyperbolic cosine
+op[ [[tanh]] ]  = function() local x=pop(); push((math.exp(2*x)-1) / (math.exp(2*x)+1)) end -- Hyperbolic tangent
+op[ [[asinh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x+1))) end -- Inverse hyperbolic sine
+op[ [[acosh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x-1))) end -- Inverse hyperbolic cosine
+op[ [[atanh]] ] = function() local x=pop(); push(math.log((1+x) / (1-x)) / 2) end -- Inverse hyperbolic tangent
 
-operatorFunc[ [[asin]] ]  = function() push(math.asin(pop())) end -- Inverse sine
-operatorFunc[ [[acos]] ]  = function() push(math.acos(pop())) end -- Inverse cosine
-operatorFunc[ [[atan]] ]  = function() push(math.atan(pop())) end -- Inverse Tangent
-operatorFunc[ [[acsc]] ]  = function() push(math.asin(1 / pop())) end -- Inverse cosecant
-operatorFunc[ [[asec]] ]  = function() push(math.acos(1 / pop())) end -- Inverse secant
-operatorFunc[ [[acot]] ]  = function() push(math.atan(1 / pop())) end -- Inverse cotangent
+op[ [[csch]] ]  = function() local x=pop(); push(2 / (math.exp(x) - math.exp(-x))) end -- Hyperbolic cosecant
+op[ [[sech]] ]  = function() local x=pop(); push(2 / (math.exp(x) + math.exp(-x))) end -- Hyperbolic secant
+op[ [[coth]] ]  = function() local x=pop(); push((math.exp(2*x)+1) / (math.exp(2*x)-1)) end -- Hyperbolic cotangent
+op[ [[acsch]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1+x*x)) / x)) end -- Inverse hyperbolic cosecant
+op[ [[asech]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1-x*x)) / x)) end -- Inverse hyperbolic secant
+op[ [[acoth]] ] = function() local x=pop(); push(math.log((x+1) / (x-1)) / 2) end -- Inverse hyperbolic cotangent
 
-operatorFunc[ [[sinh]] ]  = function() local x=pop(); push((math.exp(x) - math.exp(-x)) / 2) end -- Hyperbolic sine
-operatorFunc[ [[cosh]] ]  = function() local x=pop(); push((math.exp(x) + math.exp(-x)) / 2) end -- Hyperbolic cosine
-operatorFunc[ [[tanh]] ]  = function() local x=pop(); push((math.exp(2*x)-1) / (math.exp(2*x)+1)) end -- Hyperbolic tangent
-operatorFunc[ [[asinh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x+1))) end -- Inverse hyperbolic sine
-operatorFunc[ [[acosh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x-1))) end -- Inverse hyperbolic cosine
-operatorFunc[ [[atanh]] ] = function() local x=pop(); push(math.log((1+x) / (1-x)) / 2) end -- Inverse hyperbolic tangent
+-- Bitwise --------------------------------------------------------------------------------
+op[ [[&]] ]     = function() push(bit.band(pop(),pop())) end -- AND
+op[ [[|]] ]     = function() push(bit.bor(pop(),pop())) end -- OR
+op[ [[^]] ]     = function() push(bit.bxor(pop(),pop())) end -- XOR
+op[ [[~]] ]     = function() push(bit.bnot(pop())) end -- NOT
+op[ [[<<]] ]    = function() local n=pop(); push(bit.lshift(pop(),n)) end -- Left Shift
+op[ [[>>]] ]    = function() local n=pop(); push(bit.rshift(pop(),n)) end -- Right Shift
 
-operatorFunc[ [[csch]] ]  = function() local x=pop(); push(2 / (math.exp(x) - math.exp(-x))) end -- Hyperbolic cosecant
-operatorFunc[ [[sech]] ]  = function() local x=pop(); push(2 / (math.exp(x) + math.exp(-x))) end -- Hyperbolic secant
-operatorFunc[ [[coth]] ]  = function() local x=pop(); push((math.exp(2*x)+1) / (math.exp(2*x)-1)) end -- Hyperbolic cotangent
-operatorFunc[ [[acsch]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1+x*x)) / x)) end -- Inverse hyperbolic cosecant
-operatorFunc[ [[asech]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1-x*x)) / x)) end -- Inverse hyperbolic secant
-operatorFunc[ [[acoth]] ] = function() local x=pop(); push(math.log((x+1) / (x-1)) / 2) end -- Inverse hyperbolic cotangent
+-- Constants --------------------------------------------------------------------------------
+op[ [[pi]] ]    = function() push(math.pi) end -- 3.141592653....
+op[ [[e]] ]     = function() push(math.exp(1)) end -- 2.718281828...
+op[ [[phi]] ]   = function() push((1+math.sqrt(5)) / 2) end -- 1.618033989...
+op[ [[i]] ]     = function() push({0,1}) end -- the imaginary unit value
 
--- Bitwise
-operatorFunc[ [[&]] ]     = function() push(bit.band(pop(),pop())) end -- AND
-operatorFunc[ [[|]] ]     = function() push(bit.bor(pop(),pop())) end -- OR
-operatorFunc[ [[^]] ]     = function() push(bit.bxor(pop(),pop())) end -- XOR
-operatorFunc[ [[~]] ]     = function() push(bit.bnot(pop())) end -- NOT
-operatorFunc[ [[<<]] ]    = function() local n=pop(); push(bit.lshift(pop(),n)) end -- Left Shift
-operatorFunc[ [[>>]] ]    = function() local n=pop(); push(bit.rshift(pop(),n)) end -- Right Shift
--- Constants
-operatorFunc[ [[pi]] ]    = function() push(math.pi) end -- 3.141592653....
-operatorFunc[ [[e]] ]     = function() push(math.exp(1)) end -- 2.718281828...
-operatorFunc[ [[phi]] ]   = function() push((1+math.sqrt(5)) / 2) end -- 1.618033989...
-operatorFunc[ [[i]] ]     = function() push({0,1}) end -- the imaginary unit value
--- Other
-operatorFunc[ [[hrs]] ]   = function() push((pop() / 60 + pop()) / 60 + pop()) end -- Convert Z:Y:X to hours
-operatorFunc[ [[hms]] ]   = function() local x=pop(); for _=1,2 do local t=x<0 and math.ceil(x) or math.floor(x); push(t); x=60*(x-t); end; push(x) end -- Convert X hours to Z:Y:X
+-- Other --------------------------------------------------------------------------------
+op[ [[hrs]] ]   = function() push((pop() / 60 + pop()) / 60 + pop()) end -- Convert Z:Y:X to hours
+op[ [[hms]] ]   = function() local x=pop(); for _=1,2 do local t=x<0 and math.ceil(x) or math.floor(x); push(t); x=60*(x-t); end; push(x) end -- Convert X hours to Z:Y:X
 
--- Get all unique characters from the operatorFunc keys. These characters will
+-- Get all unique characters from the op keys. These characters will
 -- trigger completion to begin on this source.
 local function contains(table, val)
    for i=1,#table do
@@ -186,7 +190,7 @@ local function contains(table, val)
 end
 
 local triggerCharacters = vim.fn.split('0123456789.eE', '\\zs')
-for op,_ in pairs(operatorFunc) do
+for op,_ in pairs(op) do
     for char in string.gmatch(op, '.') do
         if not contains(triggerCharacters, char) then
             triggerCharacters[#triggerCharacters+1] = char
@@ -196,7 +200,7 @@ end
 
 -- Create the regex that determines if the text a valid RPN expression.
 local operators = {}
-for op,_ in pairs(operatorFunc) do
+for op,_ in pairs(op) do
     operators[#operators+1] = vim.fn.escape(op, [[~^*/\+%|<>&]] )
 end
 
@@ -235,7 +239,7 @@ source.complete = function(_, request, callback)
             local c = vim.fn.split(word, ',')
             push({tonumber(c[1]), tonumber(c[2])})
         else
-            local f = operatorFunc[word]
+            local f = op[word]
             local ok,_ = pcall(f)
             if not ok then
                 return callback({isIncomplete=true})
@@ -246,7 +250,7 @@ source.complete = function(_, request, callback)
     local value = ''
     for _,n in ipairs(stack) do
         if math.iscomplex(n) then
-            value = value .. ' ' .. n[1] .. (n[2] > 0 and '+' or '') .. n[2] .. 'i'
+            value = value .. ' ' .. n[1] .. (n[2] >= 0 and '+' or '') .. n[2] .. 'i'
         else
             value = value .. ' ' .. n
         end

--- a/lua/cmp_rpncalc/init.lua
+++ b/lua/cmp_rpncalc/init.lua
@@ -299,12 +299,85 @@ op[ [[coth]] ]  = function() -- Hyperbolic cotangent
     pcall(op[ [[tanh]] ])
     pcall(op[ [[\]] ])
 end
-op[ [[asinh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x+1))) end -- Inverse hyperbolic sine
-op[ [[acosh]] ] = function() local x=pop(); push(math.log(x + math.sqrt(x*x-1))) end -- Inverse hyperbolic cosine
-op[ [[atanh]] ] = function() local x=pop(); push(math.log((1+x) / (1-x)) / 2) end -- Inverse hyperbolic tangent
-op[ [[acsch]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1+x*x)) / x)) end -- Inverse hyperbolic cosecant
-op[ [[asech]] ] = function() local x=pop(); push(math.log((1+math.sqrt(1-x*x)) / x)) end -- Inverse hyperbolic secant
-op[ [[acoth]] ] = function() local x=pop(); push(math.log((x+1) / (x-1)) / 2) end -- Inverse hyperbolic cotangent
+-- Inverse Hyperbolic Trigonometry -------------------------------------------------------------
+op[ [[asinh]] ] = function() -- Inverse hyperbolic sine
+    local x=pop()
+    push(x)
+    push(x)
+    push(x)
+    pcall(op[ [[*]] ])
+    push(1)
+    pcall(op[ [[+]] ])
+    pcall(op[ [[sqrt]] ])
+    pcall(op[ [[+]] ])
+    pcall(op[ [[log]] ])
+end
+op[ [[acosh]] ] = function() -- Inverse hyperbolic cosine
+    local x=pop()
+    push(x)
+    push(x)
+    push(x)
+    pcall(op[ [[*]] ])
+    push(1)
+    pcall(op[ [[-]] ])
+    pcall(op[ [[sqrt]] ])
+    pcall(op[ [[+]] ])
+    pcall(op[ [[log]] ])
+end
+op[ [[atanh]] ] = function() -- Inverse hyperbolic tangent
+    local x=pop()
+    push(1)
+    push(x)
+    pcall(op[ [[+]] ])
+    push(1)
+    push(x)
+    pcall(op[ [[-]] ])
+    pcall(op[ [[/]] ])
+    pcall(op[ [[log]] ])
+    push(2)
+    pcall(op[ [[/]] ])
+end
+op[ [[acsch]] ] = function() -- Inverse hyperbolic cosecant
+    local x=pop()
+    push(1)
+    push(x)
+    push(x)
+    pcall(op[ [[*]] ])
+    pcall(op[ [[+]] ])
+    pcall(op[ [[sqrt]] ])
+    push(1)
+    pcall(op[ [[+]] ])
+    push(x)
+    pcall(op[ [[/]] ])
+    pcall(op[ [[log]] ])
+end
+op[ [[asech]] ] = function() -- Inverse hyperbolic secant
+    local x=pop()
+    push(1)
+    push(x)
+    push(x)
+    pcall(op[ [[*]] ])
+    pcall(op[ [[-]] ])
+    pcall(op[ [[sqrt]] ])
+    push(1)
+    pcall(op[ [[+]] ])
+    push(x)
+    pcall(op[ [[/]] ])
+    pcall(op[ [[log]] ])
+end
+op[ [[acoth]] ] = function() -- Inverse hyperbolic cotangent
+    local x=pop()
+    push(x)
+    push(1)
+    pcall(op[ [[+]] ])
+    push(x)
+    push(1)
+    pcall(op[ [[-]] ])
+    pcall(op[ [[/]] ])
+    pcall(op[ [[log]] ])
+    push(2)
+    pcall(op[ [[/]] ])
+end
 
 
 -- Bitwise --------------------------------------------------------------------------------

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -24,6 +24,7 @@ local assertEqual = function(expression, expected, tolerance)
             if type(expected) == 'table' then
                 -- Split complex into real and imaginary: "1.23+4.5i" -> {"1.23", "+4.5"}
                 local parts = vim.fn.split(result, '\\(\\ze[+-]\\|i\\)')
+                -- vim.pretty_print(parts)
                 -- Side effect: it also splits mantissas from exponents: "1.2e-6+9.9e-8i" -> {"1.2e", "-6", "+9.9e", "-8"}
                 -- If that happens, smash them back together again: -> {"1.2e-6", "+9.9e-8"}
                 local i = 1
@@ -34,6 +35,7 @@ local assertEqual = function(expression, expected, tolerance)
                     end
                     i = i + 1
                 end
+                -- vim.pretty_print(parts, expected)
 
                 pass = #parts == #expected and
                     math.abs(tonumber(parts[1])-expected[1]) <= tolerance and
@@ -257,6 +259,21 @@ M.run = function(verbose)
     count(assertEqual( [[0,0 0,0 **]],   'nan' ))
     count(assertEqual( [[0,0 \]],        'inf' ))
     count(assertEqual( [[2,3 \]],        {2/13, -3/13}, 1e-6))
+
+    print('Trigonometry ================================================================')
+    count(assertEqual( [[1,1 sin]], {1.298457581,0.634963915}, 1e-6))
+    count(assertEqual( [[1,1 cos]], {0.833730025,-0.988897706}, 1e-6))
+    count(assertEqual( [[1,1 tan]], {0.271752585,1.083923327}, 1e-6))
+    count(assertEqual( [[1,1 csc]], {0.621518017,-0.303931002}, 1e-6))
+    count(assertEqual( [[1,1 sec]], {0.498337031,0.591083842}, 1e-6))
+    count(assertEqual( [[1,1 cot]], {0.217621562,-0.868014143}, 1e-6))
+
+    count(assertEqual( [[1,2 sinh]], {-0.489056259,1.403119251}, 1e-6))
+    count(assertEqual( [[1,2 cosh]], {-0.642148716,1.068607421}, 1e-6))
+    count(assertEqual( [[1,2 tanh]], {1.166736257,-0.243458201}, 1e-6))
+    count(assertEqual( [[1,2 csch]], {-0.221500931,-0.635493799}, 1e-6))
+    count(assertEqual( [[1,2 sech]], {-0.413149344,-0.687527439}, 1e-6))
+    count(assertEqual( [[1,2 coth]], {0.821329797,0.171383613}, 1e-6))
 
     print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -13,7 +13,7 @@ local mockRequest = function(str)
     return { context = { cursor_before_line = str, cursor = { row = 1, col = 1 } } }
 end
 
-local assertEqual = function(expression, expected, tolerance)
+local assert = function(expression, expected, tolerance)
     local msg = type(expected) == 'table'
         and string.format('    %25s  should equal {%s, %s} ', expression, expected[1], expected[2])
         or string.format('    %25s  should equal  %s ', expression, expected)
@@ -74,227 +74,227 @@ M.run = function(verbose)
     local passedTests = 0
     local failedTests = 0
 
-    local count = function(pass)
+    local tally = function(pass)
         passedTests = passedTests + (pass and 1 or 0)
         failedTests = failedTests + (pass and 0 or 1)
     end
 
     print('No Operator (return the input) ==============================================')
-    count(assertEqual( [[12]],       [[12]] ))
-    count(assertEqual( [[1 2 3 4]],  [[1 2 3 4]] ))
+    tally(assert( [[12]],       [[12]] ))
+    tally(assert( [[1 2 3 4]],  [[1 2 3 4]] ))
 
     print('Basic Arithmetic ============================================================')
-    count(assertEqual( [[3 2 +]],     5))   -- Addtion
-    count(assertEqual( [[3.1 2.2 +]], 5.3))
-    count(assertEqual( [[13 2 -]],    11))  -- Subtraction
-    count(assertEqual( [[1.3 2 -]],   -0.7))
-    count(assertEqual( [[14 3 *]],    42))  -- Multiplication
-    count(assertEqual( [[1.4 .3 *]],  0.42))
-    count(assertEqual( [[24 8 /]],    3))   -- Division
-    count(assertEqual( [[8 24 /]],    0.333333333333, 1e-6))
-    count(assertEqual( [[7 0 /]],     'Infinity'))
-    count(assertEqual( [[0 0 /]],     'NaN'))
-    count(assertEqual( [[23 5 div]],  4))   -- Integer part of division
-    count(assertEqual( [[-23 5 div]], -4))
-    count(assertEqual( [[23 5 %]],    3))   -- Remainder of division
-    count(assertEqual( [[23 -5 %]],   -2))
-    count(assertEqual( [[-23 5 %]],   2))
-    count(assertEqual( [[-23 -5 %]],  -3))
-    count(assertEqual( [[7 abs]],     7))   -- Absolute Value
-    count(assertEqual( [[-7 abs]],    7))
-    count(assertEqual( [[1 arg]],     0 ))  -- Arg
-    count(assertEqual( [[0 arg]],     0 ))
-    count(assertEqual( [[-1 arg]],    math.pi, 1e-6 ))
-    count(assertEqual( [[-8 chs]],    8))   -- Change Sign
-    count(assertEqual( [[8 chs]],     -8))
+    tally(assert( [[3 2 +]],     5))   -- Addtion
+    tally(assert( [[3.1 2.2 +]], 5.3))
+    tally(assert( [[13 2 -]],    11))  -- Subtraction
+    tally(assert( [[1.3 2 -]],   -0.7))
+    tally(assert( [[14 3 *]],    42))  -- Multiplication
+    tally(assert( [[1.4 .3 *]],  0.42))
+    tally(assert( [[24 8 /]],    3))   -- Division
+    tally(assert( [[8 24 /]],    0.333333333333, 1e-6))
+    tally(assert( [[7 0 /]],     'Infinity'))
+    tally(assert( [[0 0 /]],     'NaN'))
+    tally(assert( [[23 5 div]],  4))   -- Integer part of division
+    tally(assert( [[-23 5 div]], -4))
+    tally(assert( [[23 5 %]],    3))   -- Remainder of division
+    tally(assert( [[23 -5 %]],   -2))
+    tally(assert( [[-23 5 %]],   2))
+    tally(assert( [[-23 -5 %]],  -3))
+    tally(assert( [[7 abs]],     7))   -- Absolute Value
+    tally(assert( [[-7 abs]],    7))
+    tally(assert( [[1 arg]],     0 ))  -- Arg
+    tally(assert( [[0 arg]],     0 ))
+    tally(assert( [[-1 arg]],    math.pi, 1e-6 ))
+    tally(assert( [[-8 chs]],    8))   -- Change Sign
+    tally(assert( [[8 chs]],     -8))
 
     print('Rounding ====================================================================')
-    count(assertEqual( [[12.3 floor]],  12 ))  -- Floor - round down to nearest integer
-    count(assertEqual( [[-12.3 floor]], -13 ))
-    count(assertEqual( [[12.3 ceil]],   13 ))  -- Ceiling - round up to nearest integer
-    count(assertEqual( [[-12.3 ceil]],  -12 ))
-    count(assertEqual( [[12.3 round]],  12 ))  -- Round to nearest integer
-    count(assertEqual( [[-12.3 round]], -12 ))
-    count(assertEqual( [[12.7 round]],  13 ))
-    count(assertEqual( [[-12.7 round]], -13 ))
-    count(assertEqual( [[12.7 trunc]],  12 ))  -- Round toward zero
-    count(assertEqual( [[-12.7 trunc]], -12 ))
+    tally(assert( [[12.3 floor]],  12 ))  -- Floor - round down to nearest integer
+    tally(assert( [[-12.3 floor]], -13 ))
+    tally(assert( [[12.3 ceil]],   13 ))  -- Ceiling - round up to nearest integer
+    tally(assert( [[-12.3 ceil]],  -12 ))
+    tally(assert( [[12.3 round]],  12 ))  -- Round to nearest integer
+    tally(assert( [[-12.3 round]], -12 ))
+    tally(assert( [[12.7 round]],  13 ))
+    tally(assert( [[-12.7 round]], -13 ))
+    tally(assert( [[12.7 trunc]],  12 ))  -- Round toward zero
+    tally(assert( [[-12.7 trunc]], -12 ))
 
     print('Powers & Logs ===============================================================')
-    count(assertEqual( [[2 exp]],       7.3890560989, 1e-6))  -- Raise e to the x power
-    count(assertEqual( [[0 exp]],       1))
-    count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6))
-    count(assertEqual( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
-    count(assertEqual( [[0 log]],       '-Infinity'))
-    count(assertEqual( [[625 5 logx]],  4))  -- Log (base x) of y
-    count(assertEqual( [[625 -5 logx]], 'NaN'))
-    count(assertEqual( [[-625 5 logx]], 'NaN'))
-    count(assertEqual( [[1000 log10]],  3))  -- Log (base 10) of x
-    count(assertEqual( [[12345 log10]], 4.0914910942, 1e-6))
-    count(assertEqual( [[1024 log2]],   10))  -- Log (base 2) of x
-    count(assertEqual( [[13 log2]],     3.7004397181, 1e-6))
-    count(assertEqual( [[36 sqrt]],     6))  -- Square Root
-    count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6))
-    count(assertEqual( [[2 3 **]],      8))  -- Exponentiation
-    count(assertEqual( [[-12 4 **]],    20736))
-    count(assertEqual( [[0 0 **]],      'NaN'))
-    count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6))
-    count(assertEqual( [[10 \]],        0.1))  -- Reciprocal
-    count(assertEqual( [[0 \]],         'Infinity'))
+    tally(assert( [[2 exp]],       7.3890560989, 1e-6))  -- Raise e to the x power
+    tally(assert( [[0 exp]],       1))
+    tally(assert( [[0.1 exp]],     1.1051709180, 1e-6))
+    tally(assert( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
+    tally(assert( [[0 log]],       '-Infinity'))
+    tally(assert( [[625 5 logx]],  4))  -- Log (base x) of y
+    tally(assert( [[625 -5 logx]], 'NaN'))
+    tally(assert( [[-625 5 logx]], 'NaN'))
+    tally(assert( [[1000 log10]],  3))  -- Log (base 10) of x
+    tally(assert( [[12345 log10]], 4.0914910942, 1e-6))
+    tally(assert( [[1024 log2]],   10))  -- Log (base 2) of x
+    tally(assert( [[13 log2]],     3.7004397181, 1e-6))
+    tally(assert( [[36 sqrt]],     6))  -- Square Root
+    tally(assert( [[23.1 sqrt]],   4.8062459362, 1e-6))
+    tally(assert( [[2 3 **]],      8))  -- Exponentiation
+    tally(assert( [[-12 4 **]],    20736))
+    tally(assert( [[0 0 **]],      'NaN'))
+    tally(assert( [[12 -0.25 **]], 0.5372849659, 1e-6))
+    tally(assert( [[10 \]],        0.1))  -- Reciprocal
+    tally(assert( [[0 \]],         'Infinity'))
 
     print('Trigonometry ================================================================')
-    count(assertEqual( [[pi 2 / deg]], 90,           1e-6))  -- convert x to degrees
-    count(assertEqual( [[90 rad]],     1.5707963267, 1e-6))  -- convert x to radians
+    tally(assert( [[pi 2 / deg]], 90,           1e-6))  -- convert x to degrees
+    tally(assert( [[90 rad]],     1.5707963267, 1e-6))  -- convert x to radians
 
-    count(assertEqual( [[30 rad sin]], 0.5 ))  -- Sine
-    count(assertEqual( [[60 rad cos]], 0.5 ))  -- Cosine
-    count(assertEqual( [[45 rad tan]], 1.0 ))  -- Tangent
-    -- count(assertEqual( [[90 rad tan]], 'Infinity' ))  -- The actual is VERY large, but not inf.
-    count(assertEqual( [[30 rad csc]], 2.0 ))  -- Cosecant
-    count(assertEqual( [[60 rad sec]], 2.0 ))  -- Secant
-    count(assertEqual( [[45 rad cot]], 1.0 ))  -- Cotangent
-    count(assertEqual( [[0 cot]],      'Infinity' ))  -- Cotangent
+    tally(assert( [[30 rad sin]], 0.5 ))  -- Sine
+    tally(assert( [[60 rad cos]], 0.5 ))  -- Cosine
+    tally(assert( [[45 rad tan]], 1.0 ))  -- Tangent
+    -- tally(assert( [[90 rad tan]], 'Infinity' ))  -- The actual is VERY large, but not inf.
+    tally(assert( [[30 rad csc]], 2.0 ))  -- Cosecant
+    tally(assert( [[60 rad sec]], 2.0 ))  -- Secant
+    tally(assert( [[45 rad cot]], 1.0 ))  -- Cotangent
+    tally(assert( [[0 cot]],      'Infinity' ))  -- Cotangent
 
-    count(assertEqual( [[0.5 asin deg]], 30 ))  -- Inverse sine
-    count(assertEqual( [[10 asin]],      'NaN' ))
-    count(assertEqual( [[0.5 acos deg]], 60 ))  -- Inverse cosine
-    count(assertEqual( [[-10 acos]],     'NaN' ))
-    count(assertEqual( [[1 atan deg]],   45 ))    -- Inverse Tangent
-    count(assertEqual( [[2.0 acsc deg]], 30 ))  -- Inverse cosecant
-    count(assertEqual( [[0 acsc]],       'NaN' ))  -- Inverse cosecant
-    count(assertEqual( [[2.0 asec deg]], 60 ))  -- Inverse secant
-    count(assertEqual( [[0 asec]],       'NaN' ))  -- Inverse secant
-    count(assertEqual( [[1 acot deg]],   45 ))  -- Inverse cotangent
+    tally(assert( [[0.5 asin deg]], 30 ))  -- Inverse sine
+    tally(assert( [[10 asin]],      'NaN' ))
+    tally(assert( [[0.5 acos deg]], 60 ))  -- Inverse cosine
+    tally(assert( [[-10 acos]],     'NaN' ))
+    tally(assert( [[1 atan deg]],   45 ))    -- Inverse Tangent
+    tally(assert( [[2.0 acsc deg]], 30 ))  -- Inverse cosecant
+    tally(assert( [[0 acsc]],       'NaN' ))  -- Inverse cosecant
+    tally(assert( [[2.0 asec deg]], 60 ))  -- Inverse secant
+    tally(assert( [[0 asec]],       'NaN' ))  -- Inverse secant
+    tally(assert( [[1 acot deg]],   45 ))  -- Inverse cotangent
 
-    count(assertEqual( [[2 sinh]],             3.6268604078, 1e-6 )) -- Hyperbolic sine
-    count(assertEqual( [[4 cosh]],             27.308232836, 1e-6 )) -- Hyperbolic cosine
-    count(assertEqual( [[-0.5 tanh]],          -0.462117157, 1e-6 )) -- Hyperbolic tangent
-    count(assertEqual( [[3.6268604079 asinh]], 2.0, 1e-6 )) -- Inverse hyperbolic sine
-    count(assertEqual( [[27.30823284 acosh]],  4.0, 1e-6 )) -- Inverse hyperbolic cosine
-    count(assertEqual( [[-0.462117157 atanh]], -0.5, 1e-6 )) -- Inverse hyperbolic tangent
-    count(assertEqual( [[1 atanh]],            'Infinity' ))
-    count(assertEqual( [[-1 atanh]],           '-Infinity' ))
-    count(assertEqual( [[10 atanh]],           'NaN' ))
+    tally(assert( [[2 sinh]],             3.6268604078, 1e-6 )) -- Hyperbolic sine
+    tally(assert( [[4 cosh]],             27.308232836, 1e-6 )) -- Hyperbolic cosine
+    tally(assert( [[-0.5 tanh]],          -0.462117157, 1e-6 )) -- Hyperbolic tangent
+    tally(assert( [[3.6268604079 asinh]], 2.0, 1e-6 )) -- Inverse hyperbolic sine
+    tally(assert( [[27.30823284 acosh]],  4.0, 1e-6 )) -- Inverse hyperbolic cosine
+    tally(assert( [[-0.462117157 atanh]], -0.5, 1e-6 )) -- Inverse hyperbolic tangent
+    tally(assert( [[1 atanh]],            'Infinity' ))
+    tally(assert( [[-1 atanh]],           '-Infinity' ))
+    tally(assert( [[10 atanh]],           'NaN' ))
 
-    count(assertEqual( [[2 csch]],              0.27572056, 1e-6 ))  -- Hyperbolic cosecant
-    count(assertEqual( [[0 csch]],              'Infinity' ))
-    count(assertEqual( [[-5 sech]],             0.013475282, 1e-6 ))  -- Hyperbolic secant
-    count(assertEqual( [[0 sech]],              1 ))
-    count(assertEqual( [[0.5 coth]],            2.16395341373, 1e-6 ))  -- Hyperbolic cotangent
-    count(assertEqual( [[0 coth]],              'Infinity' ))
-    count(assertEqual( [[0.27572056 acsch]],    2.0, 1e-6 ))  -- Inverse hyperbolic cosecant
-    count(assertEqual( [[0 acsch]],             'Infinity' ))
-    count(assertEqual( [[0.013475282 asech]],   5.0, 1e-6 ))  -- Inverse hyperbolic secant
-    count(assertEqual( [[2.16395341373 acoth]], 0.5, 1e-6 ))  -- Inverse hyperbolic cotangent
-    count(assertEqual( [[0 acoth]],             'NaN' ))
+    tally(assert( [[2 csch]],              0.27572056, 1e-6 ))  -- Hyperbolic cosecant
+    tally(assert( [[0 csch]],              'Infinity' ))
+    tally(assert( [[-5 sech]],             0.013475282, 1e-6 ))  -- Hyperbolic secant
+    tally(assert( [[0 sech]],              1 ))
+    tally(assert( [[0.5 coth]],            2.16395341373, 1e-6 ))  -- Hyperbolic cotangent
+    tally(assert( [[0 coth]],              'Infinity' ))
+    tally(assert( [[0.27572056 acsch]],    2.0, 1e-6 ))  -- Inverse hyperbolic cosecant
+    tally(assert( [[0 acsch]],             'Infinity' ))
+    tally(assert( [[0.013475282 asech]],   5.0, 1e-6 ))  -- Inverse hyperbolic secant
+    tally(assert( [[2.16395341373 acoth]], 0.5, 1e-6 ))  -- Inverse hyperbolic cotangent
+    tally(assert( [[0 acoth]],             'NaN' ))
 
     print('Bitwise =====================================================================')
-    count(assertEqual( [[60 13 &]], 12 ))   -- AND
-    count(assertEqual( [[60 13 |]], 61 ))   -- OR
-    count(assertEqual( [[60 13 ^]], 49 ))   -- XOR
-    count(assertEqual( [[60 ~]],    -61 ))  -- NOT
-    count(assertEqual( [[60 2 <<]], 240 ))  -- Left Shift
-    count(assertEqual( [[60 2 >>]], 15 ))   -- Right Shift
+    tally(assert( [[60 13 &]], 12 ))   -- AND
+    tally(assert( [[60 13 |]], 61 ))   -- OR
+    tally(assert( [[60 13 ^]], 49 ))   -- XOR
+    tally(assert( [[60 ~]],    -61 ))  -- NOT
+    tally(assert( [[60 2 <<]], 240 ))  -- Left Shift
+    tally(assert( [[60 2 >>]], 15 ))   -- Right Shift
 
     print('Constants ===================================================================')
-    count(assertEqual( [[pi]],  3.1415926535, 1e-6 ))  -- 3.141592653....
-    count(assertEqual( [[e]],   2.7182818284, 1e-6 ))  -- 2.718281828...
-    count(assertEqual( [[phi]], 1.6180339887, 1e-6 ))  -- golden ratio
-    count(assertEqual( [[i]],   {0,1} ))
+    tally(assert( [[pi]],  3.1415926535, 1e-6 ))  -- 3.141592653....
+    tally(assert( [[e]],   2.7182818284, 1e-6 ))  -- 2.718281828...
+    tally(assert( [[phi]], 1.6180339887, 1e-6 ))  -- golden ratio
+    tally(assert( [[i]],   {0,1} ))
 
     print('Other =======================================================================')
-    count(assertEqual( [[3 20 15 hrs]], 3.3375 ))  -- Convert Z:Y:X to hours
-    count(assertEqual( [[3.3375 hms]], [[3 20 15]] ))  -- Convert X hours to Z:Y:X
+    tally(assert( [[3 20 15 hrs]], 3.3375 ))  -- Convert Z:Y:X to hours
+    tally(assert( [[3.3375 hms]], [[3 20 15]] ))  -- Convert X hours to Z:Y:X
 
     print('AGAIN, BUT WITH COMPLEX NUMBERS ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~')
 
     print('No Operator (return the input) ==============================================')
-    count(assertEqual( [[12,2]],       {12,2} ))
-    count(assertEqual( [[1,-2 3,4]],  [[1-2i 3+4i]] ))
+    tally(assert( [[12,2]],       {12,2} ))
+    tally(assert( [[1,-2 3,4]],  [[1-2i 3+4i]] ))
 
     print('Basic Arithmetic ============================================================')
-    count(assertEqual( [[3,1  2,6 +]],    {5,7} ))   -- Addtion
-    count(assertEqual( [[3.5  2,6 +]],    {5.5,6} ))
-    count(assertEqual( [[3,1  6 +]],      {9,1} ))
-    count(assertEqual( [[13,4 2,2 -]],    {11,2} ))  -- Subtraction
-    count(assertEqual( [[13   2,2 -]],    {11,-2} ))
-    count(assertEqual( [[13,4 2 -]],      {11,4} ))
-    count(assertEqual( [[1,4  3,2 *]],    {-5,14} ))  -- Multiplication
-    count(assertEqual( [[4    3,2 *]],    {12,8} ))
-    count(assertEqual( [[1,4  3 *]],      {3,12} ))
-    count(assertEqual( [[2,4  2 /]],      {1,2} ))   -- Division
-    count(assertEqual( [[2    4,2 /]],    {0.4,-0.2} ))
-    count(assertEqual( [[3,-1 4,2 /]],    {0.5,-0.5} ))
+    tally(assert( [[3,1  2,6 +]],    {5,7} ))   -- Addtion
+    tally(assert( [[3.5  2,6 +]],    {5.5,6} ))
+    tally(assert( [[3,1  6 +]],      {9,1} ))
+    tally(assert( [[13,4 2,2 -]],    {11,2} ))  -- Subtraction
+    tally(assert( [[13   2,2 -]],    {11,-2} ))
+    tally(assert( [[13,4 2 -]],      {11,4} ))
+    tally(assert( [[1,4  3,2 *]],    {-5,14} ))  -- Multiplication
+    tally(assert( [[4    3,2 *]],    {12,8} ))
+    tally(assert( [[1,4  3 *]],      {3,12} ))
+    tally(assert( [[2,4  2 /]],      {1,2} ))   -- Division
+    tally(assert( [[2    4,2 /]],    {0.4,-0.2} ))
+    tally(assert( [[3,-1 4,2 /]],    {0.5,-0.5} ))
 
-    count(assertEqual( [[3,4 abs]],     5 ))   -- Absolute Value
+    tally(assert( [[3,4 abs]],     5 ))   -- Absolute Value
 
-    count(assertEqual( [[1,1 arg]],     0.78539816339745, 1e-6 ))  -- Arg
-    count(assertEqual( [[-3,1 arg]],     2.8198420991932, 1e-6 ))
-    count(assertEqual( [[-3,-2 arg]],     -2.5535900500422, 1e-6 ))
-    count(assertEqual( [[2,-1 arg]],     -0.46364760900081, 1e-6 ))
+    tally(assert( [[1,1 arg]],     0.78539816339745, 1e-6 ))  -- Arg
+    tally(assert( [[-3,1 arg]],     2.8198420991932, 1e-6 ))
+    tally(assert( [[-3,-2 arg]],     -2.5535900500422, 1e-6 ))
+    tally(assert( [[2,-1 arg]],     -0.46364760900081, 1e-6 ))
 
-    count(assertEqual( [[-8,2 chs]],    {8,-2} ))   -- Change Sign
+    tally(assert( [[-8,2 chs]],    {8,-2} ))   -- Change Sign
 
     print('Rounding ====================================================================')
-    count(assertEqual( [[12.3,4.2 floor]],   {12,4} ))  -- Floor - round down to nearest integer
-    count(assertEqual( [[-12.3,-4.2 floor]], {-13,-5} ))
-    count(assertEqual( [[12.3,4.2 ceil]],    {13,5} ))  -- Ceiling - round up to nearest integer
-    count(assertEqual( [[-12.3,-4.2 ceil]],  {-12,-4} ))
-    count(assertEqual( [[12.3,4.7 round]],   {12,5} ))  -- Round to nearest integer
-    count(assertEqual( [[-12.3,-4.7 round]], {-12,-5} ))
-    count(assertEqual( [[12.7,4.3 round]],   {13,4} ))
-    count(assertEqual( [[-12.7,-4.3 round]], {-13,-4} ))
-    count(assertEqual( [[12.7,4.3 trunc]],   {12,4} ))  -- Round toward zero
-    count(assertEqual( [[-12.7,-4.3 trunc]], {-12,-4} ))
+    tally(assert( [[12.3,4.2 floor]],   {12,4} ))  -- Floor - round down to nearest integer
+    tally(assert( [[-12.3,-4.2 floor]], {-13,-5} ))
+    tally(assert( [[12.3,4.2 ceil]],    {13,5} ))  -- Ceiling - round up to nearest integer
+    tally(assert( [[-12.3,-4.2 ceil]],  {-12,-4} ))
+    tally(assert( [[12.3,4.7 round]],   {12,5} ))  -- Round to nearest integer
+    tally(assert( [[-12.3,-4.7 round]], {-12,-5} ))
+    tally(assert( [[12.7,4.3 round]],   {13,4} ))
+    tally(assert( [[-12.7,-4.3 round]], {-13,-4} ))
+    tally(assert( [[12.7,4.3 trunc]],   {12,4} ))  -- Round toward zero
+    tally(assert( [[-12.7,-4.3 trunc]], {-12,-4} ))
 
     print('Powers & Logs ===============================================================')
-    count(assertEqual( [[2,1 exp]],      {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the x power
-    count(assertEqual( [[2,3 log]],      {1.282474678,0.982793723}, 1e-6 ))  -- Natural log of x
-    count(assertEqual( [[2,3 log10]],    {0.556971676,0.426821891}, 1e-6 ))  -- Log (base 10) of x
-    count(assertEqual( [[2,3 log2]],     {1.850219859,1.417871631}, 1e-6 ))  -- Log (base 2) of x
-    count(assertEqual( [[2,3 1,2 logx]], {1.131731655,-0.335771298}, 1e-6 ))  -- Log (base x) of y
-    count(assertEqual( [[-4 sqrt]],      {0,2}, 1e-6))  -- Square root
-    count(assertEqual( [[2,3.1 sqrt]],   {1.6865902,0.91901396}, 1e-6 ))
-    count(assertEqual( [[0,1 2 **]],     {-1,0}, 1e-6 ))  -- Exponentiation
-    count(assertEqual( [[0,1 3 **]],     {0,-1}, 1e-6 ))
-    count(assertEqual( [[1,1 2 **]],     {0,2}, 1e-6 ))
-    count(assertEqual( [[3 1,-2 **]],    {-1.7587648,-2.4303798}, 1e-6))
-    count(assertEqual( [[-4,3 1,-2 **]], {555.3814991,-487.8784553}, 1e-6))
-    count(assertEqual( [[-7 3.3 **]],    {-361.4449966, -497.4863586}, 1e-6))
-    count(assertEqual( [[0,0 0 **]],     'NaN' ))
-    count(assertEqual( [[0 0,0 **]],     'NaN' ))
-    count(assertEqual( [[0,0 0,0 **]],   'NaN' ))
-    count(assertEqual( [[0,0 \]],        'NaN' ))
-    count(assertEqual( [[2,3 \]],        {2/13, -3/13}, 1e-6))
+    tally(assert( [[2,1 exp]],      {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the x power
+    tally(assert( [[2,3 log]],      {1.282474678,0.982793723}, 1e-6 ))  -- Natural log of x
+    tally(assert( [[2,3 log10]],    {0.556971676,0.426821891}, 1e-6 ))  -- Log (base 10) of x
+    tally(assert( [[2,3 log2]],     {1.850219859,1.417871631}, 1e-6 ))  -- Log (base 2) of x
+    tally(assert( [[2,3 1,2 logx]], {1.131731655,-0.335771298}, 1e-6 ))  -- Log (base x) of y
+    tally(assert( [[-4 sqrt]],      {0,2}, 1e-6))  -- Square root
+    tally(assert( [[2,3.1 sqrt]],   {1.6865902,0.91901396}, 1e-6 ))
+    tally(assert( [[0,1 2 **]],     {-1,0}, 1e-6 ))  -- Exponentiation
+    tally(assert( [[0,1 3 **]],     {0,-1}, 1e-6 ))
+    tally(assert( [[1,1 2 **]],     {0,2}, 1e-6 ))
+    tally(assert( [[3 1,-2 **]],    {-1.7587648,-2.4303798}, 1e-6))
+    tally(assert( [[-4,3 1,-2 **]], {555.3814991,-487.8784553}, 1e-6))
+    tally(assert( [[-7 3.3 **]],    {-361.4449966, -497.4863586}, 1e-6))
+    tally(assert( [[0,0 0 **]],     'NaN' ))
+    tally(assert( [[0 0,0 **]],     'NaN' ))
+    tally(assert( [[0,0 0,0 **]],   'NaN' ))
+    tally(assert( [[0,0 \]],        'NaN' ))
+    tally(assert( [[2,3 \]],        {2/13, -3/13}, 1e-6))
 
     print('Trigonometry ================================================================')
-    count(assertEqual( [[1,1 sin]], {1.298457581,0.634963915}, 1e-6))
-    count(assertEqual( [[1,1 cos]], {0.833730025,-0.988897706}, 1e-6))
-    count(assertEqual( [[1,1 tan]], {0.271752585,1.083923327}, 1e-6))
-    count(assertEqual( [[1,1 csc]], {0.621518017,-0.303931002}, 1e-6))
-    count(assertEqual( [[1,1 sec]], {0.498337031,0.591083842}, 1e-6))
-    count(assertEqual( [[1,1 cot]], {0.217621562,-0.868014143}, 1e-6))
+    tally(assert( [[1,1 sin]], {1.298457581,0.634963915}, 1e-6))
+    tally(assert( [[1,1 cos]], {0.833730025,-0.988897706}, 1e-6))
+    tally(assert( [[1,1 tan]], {0.271752585,1.083923327}, 1e-6))
+    tally(assert( [[1,1 csc]], {0.621518017,-0.303931002}, 1e-6))
+    tally(assert( [[1,1 sec]], {0.498337031,0.591083842}, 1e-6))
+    tally(assert( [[1,1 cot]], {0.217621562,-0.868014143}, 1e-6))
 
-    count(assertEqual( [[1,2 sinh]], {-0.489056259,1.403119251}, 1e-6))
-    count(assertEqual( [[1,2 cosh]], {-0.642148716,1.068607421}, 1e-6))
-    count(assertEqual( [[1,2 tanh]], {1.166736257,-0.243458201}, 1e-6))
-    count(assertEqual( [[1,2 csch]], {-0.221500931,-0.635493799}, 1e-6))
-    count(assertEqual( [[1,2 sech]], {-0.413149344,-0.687527439}, 1e-6))
-    count(assertEqual( [[1,2 coth]], {0.821329797,0.171383613}, 1e-6))
+    tally(assert( [[1,2 sinh]], {-0.489056259,1.403119251}, 1e-6))
+    tally(assert( [[1,2 cosh]], {-0.642148716,1.068607421}, 1e-6))
+    tally(assert( [[1,2 tanh]], {1.166736257,-0.243458201}, 1e-6))
+    tally(assert( [[1,2 csch]], {-0.221500931,-0.635493799}, 1e-6))
+    tally(assert( [[1,2 sech]], {-0.413149344,-0.687527439}, 1e-6))
+    tally(assert( [[1,2 coth]], {0.821329797,0.171383613}, 1e-6))
 
-    count(assertEqual( [[1,1 asin]], {0.666239432,1.061275062}, 1e-6))
-    count(assertEqual( [[1,1 acos]], {0.904556894,-1.061275062}, 1e-6))
-    count(assertEqual( [[1,1 atan]], {1.017221968,0.402359478}, 1e-6))
-    count(assertEqual( [[1,1 acsc]], {0.452278447,-0.530637531}, 1e-6))
-    count(assertEqual( [[1,1 asec]], {1.118517880,0.530637531}, 1e-6))
-    count(assertEqual( [[1,1 acot]], {0.553574359,-0.402359478}, 1e-6))
+    tally(assert( [[1,1 asin]], {0.666239432,1.061275062}, 1e-6))
+    tally(assert( [[1,1 acos]], {0.904556894,-1.061275062}, 1e-6))
+    tally(assert( [[1,1 atan]], {1.017221968,0.402359478}, 1e-6))
+    tally(assert( [[1,1 acsc]], {0.452278447,-0.530637531}, 1e-6))
+    tally(assert( [[1,1 asec]], {1.118517880,0.530637531}, 1e-6))
+    tally(assert( [[1,1 acot]], {0.553574359,-0.402359478}, 1e-6))
 
-    count(assertEqual( [[1,1 asinh]], {1.061275062,0.666239432}, 1e-6))
-    count(assertEqual( [[1,1 acosh]], {1.061275062,0.904556894}, 1e-6))
-    count(assertEqual( [[1,1 atanh]], {0.402359478,1.017221968}, 1e-6))
-    count(assertEqual( [[1,1 acsch]], {0.530637531,-0.452278447}, 1e-6))
-    count(assertEqual( [[1,1 asech]], {0.530637531,-1.118517880}, 1e-6))
-    count(assertEqual( [[1,1 acoth]], {0.402359478,-0.553574359}, 1e-6))
+    tally(assert( [[1,1 asinh]], {1.061275062,0.666239432}, 1e-6))
+    tally(assert( [[1,1 acosh]], {1.061275062,0.904556894}, 1e-6))
+    tally(assert( [[1,1 atanh]], {0.402359478,1.017221968}, 1e-6))
+    tally(assert( [[1,1 acsch]], {0.530637531,-0.452278447}, 1e-6))
+    tally(assert( [[1,1 asech]], {0.530637531,-1.118517880}, 1e-6))
+    tally(assert( [[1,1 acoth]], {0.402359478,-0.553574359}, 1e-6))
 
     print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -114,7 +114,7 @@ M.run = function(verbose)
     count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6))
     count(assertEqual( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
     count(assertEqual( [[0 log]],       '-inf'))
-    count(assertEqual( [[625 5 logx]],  4))  -- Log y of x
+    count(assertEqual( [[625 5 logx]],  4))  -- Log (base x) of y
     count(assertEqual( [[625 -5 logx]], 'nan'))
     count(assertEqual( [[-625 5 logx]], 'nan'))
     count(assertEqual( [[1000 log10]],  3))  -- Log (base 10) of x
@@ -125,7 +125,6 @@ M.run = function(verbose)
     count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6))
     count(assertEqual( [[2 3 **]],      8))  -- Exponentiation
     count(assertEqual( [[-12 4 **]],    20736))
-    count(assertEqual( [[-7 3.3 **]],   'nan'))
     count(assertEqual( [[0 0 **]],      'nan'))
     count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6))
     count(assertEqual( [[10 \]],        0.1))  -- Reciprocal
@@ -240,37 +239,24 @@ M.run = function(verbose)
     count(assertEqual( [[-12.7,-4.3 trunc]], {-12,-4} ))
 
     print('Powers & Logs ===============================================================')
-    -- count(assertEqual( [[2,1 exp]],   {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the a complex power
-
--- e^(a+bi)
--- (e^a)*(e*bi)
--- (e^a)*(cos(b)+i*sin(b))
--- {(e^a)cos(b), (e^a)sin(b)}
-
-
-    -- count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6 ))
-    -- count(assertEqual( [[120 log]],     4.7874917427, 1e-6 ))  -- Natural log of x
-    -- count(assertEqual( [[0 log]],       '-inf' ))
-    -- count(assertEqual( [[625 5 logx]],  4 ))  -- Log y of x
-    -- count(assertEqual( [[625 -5 logx]], 'nan' ))
-    -- count(assertEqual( [[-625 5 logx]], 'nan' ))
-    -- count(assertEqual( [[1000 log10]],  3 ))  -- Log (base 10) of x
-    -- count(assertEqual( [[12345 log10]], 4.0914910942, 1e-6 ))
-    -- count(assertEqual( [[1024 log2]],   10 ))  -- Log (base 2) of x
-    -- count(assertEqual( [[13 log2]],     3.7004397181, 1e-6 ))
-    -- count(assertEqual( [[36 sqrt]],     6 ))  -- Square Root
-    count(assertEqual( [[-4 sqrt]],     {0,2} ))
-    -- count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6 ))
-    count(assertEqual( [[0,1 2 **]],      {-1,0}, 1e-6 ))  -- Exponentiation
-    count(assertEqual( [[0,1 3 **]],    {0,-1}, 1e-6 ))
-    count(assertEqual( [[1,1 2 **]],    {0,2}, 1e-6 ))
-    count(assertEqual( [[3 1,-2 **]],   {-1.7587648,-2.4303798}, 1e-6))
-    count(assertEqual( [[-4,3 1,-2 **]],   {555.3814991,-487.8784553}, 1e-6))
-    -- count(assertEqual( [[-7 3.3 **]],   'nan' ))
-    -- count(assertEqual( [[0 0 **]],      'nan' ))
-    -- count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6 ))
-    -- count(assertEqual( [[10 \]],       0.1 ))  -- Reciprocal
-    -- count(assertEqual( [[0 \]],        'inf' ))
+    count(assertEqual( [[2,1 exp]],      {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the x power
+    count(assertEqual( [[2,3 log]],      {1.282474678,0.982793723}, 1e-6 ))  -- Natural log of x
+    count(assertEqual( [[2,3 log10]],    {0.556971676,0.426821891}, 1e-6 ))  -- Log (base 10) of x
+    count(assertEqual( [[2,3 log2]],     {1.850219859,1.417871631}, 1e-6 ))  -- Log (base 2) of x
+    count(assertEqual( [[2,3 1,2 logx]], {1.131731655,-0.335771298}, 1e-6 ))  -- Log (base x) of y
+    count(assertEqual( [[-4 sqrt]],      {0,2}, 1e-6))  -- Square root
+    count(assertEqual( [[2,3.1 sqrt]],   {1.6865902,0.91901396}, 1e-6 ))
+    count(assertEqual( [[0,1 2 **]],     {-1,0}, 1e-6 ))  -- Exponentiation
+    count(assertEqual( [[0,1 3 **]],     {0,-1}, 1e-6 ))
+    count(assertEqual( [[1,1 2 **]],     {0,2}, 1e-6 ))
+    count(assertEqual( [[3 1,-2 **]],    {-1.7587648,-2.4303798}, 1e-6))
+    count(assertEqual( [[-4,3 1,-2 **]], {555.3814991,-487.8784553}, 1e-6))
+    count(assertEqual( [[-7 3.3 **]],    {-361.4449966, -497.4863586}, 1e-6))
+    count(assertEqual( [[0,0 0 **]],     'nan' ))
+    count(assertEqual( [[0 0,0 **]],     'nan' ))
+    count(assertEqual( [[0,0 0,0 **]],   'nan' ))
+    count(assertEqual( [[0,0 \]],        'inf' ))
+    count(assertEqual( [[2,3 \]],        {2/13, -3/13}, 1e-6))
 
     print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -85,8 +85,8 @@ M.run = function(verbose)
     count(assertEqual( [[1.4 .3 *]],  0.42))
     count(assertEqual( [[24 8 /]],    3))   -- Division
     count(assertEqual( [[8 24 /]],    0.333333333333, 1e-6))
-    count(assertEqual( [[7 0 /]],     'inf'))
-    count(assertEqual( [[0 0 /]],     'nan'))
+    count(assertEqual( [[7 0 /]],     'Infinity'))
+    count(assertEqual( [[0 0 /]],     'NaN'))
     count(assertEqual( [[23 5 div]],  4))   -- Integer part of division
     count(assertEqual( [[-23 5 div]], -4))
     count(assertEqual( [[23 5 %]],    3))   -- Remainder of division
@@ -115,10 +115,10 @@ M.run = function(verbose)
     count(assertEqual( [[0 exp]],       1))
     count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6))
     count(assertEqual( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
-    count(assertEqual( [[0 log]],       '-inf'))
+    count(assertEqual( [[0 log]],       '-Infinity'))
     count(assertEqual( [[625 5 logx]],  4))  -- Log (base x) of y
-    count(assertEqual( [[625 -5 logx]], 'nan'))
-    count(assertEqual( [[-625 5 logx]], 'nan'))
+    count(assertEqual( [[625 -5 logx]], 'NaN'))
+    count(assertEqual( [[-625 5 logx]], 'NaN'))
     count(assertEqual( [[1000 log10]],  3))  -- Log (base 10) of x
     count(assertEqual( [[12345 log10]], 4.0914910942, 1e-6))
     count(assertEqual( [[1024 log2]],   10))  -- Log (base 2) of x
@@ -127,10 +127,10 @@ M.run = function(verbose)
     count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6))
     count(assertEqual( [[2 3 **]],      8))  -- Exponentiation
     count(assertEqual( [[-12 4 **]],    20736))
-    count(assertEqual( [[0 0 **]],      'nan'))
+    count(assertEqual( [[0 0 **]],      'NaN'))
     count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6))
     count(assertEqual( [[10 \]],        0.1))  -- Reciprocal
-    count(assertEqual( [[0 \]],         'inf'))
+    count(assertEqual( [[0 \]],         'Infinity'))
 
     print('Trigonometry ================================================================')
     count(assertEqual( [[pi 2 / deg]], 90,           1e-6))  -- convert x to degrees
@@ -139,21 +139,21 @@ M.run = function(verbose)
     count(assertEqual( [[30 rad sin]], 0.5 ))  -- Sine
     count(assertEqual( [[60 rad cos]], 0.5 ))  -- Cosine
     count(assertEqual( [[45 rad tan]], 1.0 ))  -- Tangent
-    -- count(assertEqual( [[90 rad tan]], 'inf' ))  -- The actual is VERY large, but not inf.
+    -- count(assertEqual( [[90 rad tan]], 'Infinity' ))  -- The actual is VERY large, but not inf.
     count(assertEqual( [[30 rad csc]], 2.0 ))  -- Cosecant
     count(assertEqual( [[60 rad sec]], 2.0 ))  -- Secant
     count(assertEqual( [[45 rad cot]], 1.0 ))  -- Cotangent
-    count(assertEqual( [[0 cot]],      'inf' ))  -- Cotangent
+    count(assertEqual( [[0 cot]],      'Infinity' ))  -- Cotangent
 
     count(assertEqual( [[0.5 asin deg]], 30 ))  -- Inverse sine
-    count(assertEqual( [[10 asin]],      'nan' ))
+    count(assertEqual( [[10 asin]],      'NaN' ))
     count(assertEqual( [[0.5 acos deg]], 60 ))  -- Inverse cosine
-    count(assertEqual( [[-10 acos]],     'nan' ))
+    count(assertEqual( [[-10 acos]],     'NaN' ))
     count(assertEqual( [[1 atan deg]],   45 ))    -- Inverse Tangent
     count(assertEqual( [[2.0 acsc deg]], 30 ))  -- Inverse cosecant
-    count(assertEqual( [[0 acsc]],       'nan' ))  -- Inverse cosecant
+    count(assertEqual( [[0 acsc]],       'NaN' ))  -- Inverse cosecant
     count(assertEqual( [[2.0 asec deg]], 60 ))  -- Inverse secant
-    count(assertEqual( [[0 asec]],       'nan' ))  -- Inverse secant
+    count(assertEqual( [[0 asec]],       'NaN' ))  -- Inverse secant
     count(assertEqual( [[1 acot deg]],   45 ))  -- Inverse cotangent
 
     count(assertEqual( [[2 sinh]],             3.6268604078, 1e-6 )) -- Hyperbolic sine
@@ -162,21 +162,21 @@ M.run = function(verbose)
     count(assertEqual( [[3.6268604079 asinh]], 2.0, 1e-6 )) -- Inverse hyperbolic sine
     count(assertEqual( [[27.30823284 acosh]],  4.0, 1e-6 )) -- Inverse hyperbolic cosine
     count(assertEqual( [[-0.462117157 atanh]], -0.5, 1e-6 )) -- Inverse hyperbolic tangent
-    count(assertEqual( [[1 atanh]],            'inf' ))
-    count(assertEqual( [[-1 atanh]],           '-inf' ))
-    count(assertEqual( [[10 atanh]],           'nan' ))
+    count(assertEqual( [[1 atanh]],            'Infinity' ))
+    count(assertEqual( [[-1 atanh]],           '-Infinity' ))
+    count(assertEqual( [[10 atanh]],           'NaN' ))
 
     count(assertEqual( [[2 csch]],              0.27572056, 1e-6 ))  -- Hyperbolic cosecant
-    count(assertEqual( [[0 csch]],              'inf' ))
+    count(assertEqual( [[0 csch]],              'Infinity' ))
     count(assertEqual( [[-5 sech]],             0.013475282, 1e-6 ))  -- Hyperbolic secant
     count(assertEqual( [[0 sech]],              1 ))
     count(assertEqual( [[0.5 coth]],            2.16395341373, 1e-6 ))  -- Hyperbolic cotangent
-    count(assertEqual( [[0 coth]],              'inf' ))
+    count(assertEqual( [[0 coth]],              'Infinity' ))
     count(assertEqual( [[0.27572056 acsch]],    2.0, 1e-6 ))  -- Inverse hyperbolic cosecant
-    count(assertEqual( [[0 acsch]],             'inf' ))
+    count(assertEqual( [[0 acsch]],             'Infinity' ))
     count(assertEqual( [[0.013475282 asech]],   5.0, 1e-6 ))  -- Inverse hyperbolic secant
     count(assertEqual( [[2.16395341373 acoth]], 0.5, 1e-6 ))  -- Inverse hyperbolic cotangent
-    count(assertEqual( [[0 acoth]],             'nan' ))
+    count(assertEqual( [[0 acoth]],             'NaN' ))
 
     print('Bitwise =====================================================================')
     count(assertEqual( [[60 13 &]], 12 ))   -- AND
@@ -252,10 +252,10 @@ M.run = function(verbose)
     count(assertEqual( [[3 1,-2 **]],    {-1.7587648,-2.4303798}, 1e-6))
     count(assertEqual( [[-4,3 1,-2 **]], {555.3814991,-487.8784553}, 1e-6))
     count(assertEqual( [[-7 3.3 **]],    {-361.4449966, -497.4863586}, 1e-6))
-    count(assertEqual( [[0,0 0 **]],     'nan' ))
-    count(assertEqual( [[0 0,0 **]],     'nan' ))
-    count(assertEqual( [[0,0 0,0 **]],   'nan' ))
-    count(assertEqual( [[0,0 \]],        'inf' ))
+    count(assertEqual( [[0,0 0 **]],     'NaN' ))
+    count(assertEqual( [[0 0,0 **]],     'NaN' ))
+    count(assertEqual( [[0,0 0,0 **]],   'NaN' ))
+    count(assertEqual( [[0,0 \]],        'NaN' ))
     count(assertEqual( [[2,3 \]],        {2/13, -3/13}, 1e-6))
 
     print('Trigonometry ================================================================')

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -1,3 +1,10 @@
+-- To run the tests, use these commands:
+--
+-- :wa|mess clear|lua require('cmp_rpncalc.tests').rerun(false)
+--          - false prints only failure messages
+--          - true prints all messages
+-- :messages
+
 M = {}
 
 local printAll = false
@@ -53,12 +60,12 @@ local assertEqual = function(expression, expected, tolerance)
     return pass
 end
 
+-- Rerun the tests after reloading (and recompiling) the source and test code.
 M.rerun = function(verbose)
     vim.schedule(function()
         package.loaded['cmp_rpncalc'] = nil
         package.loaded['cmp_rpncalc.tests'] = nil
         require('cmp_rpncalc.tests').run(verbose)
-        vim.cmd('messages')
     end)
 end
 
@@ -95,6 +102,9 @@ M.run = function(verbose)
     count(assertEqual( [[-23 -5 %]],  -3))
     count(assertEqual( [[7 abs]],     7))   -- Absolute Value
     count(assertEqual( [[-7 abs]],    7))
+    count(assertEqual( [[1 arg]],     0 ))  -- Arg
+    count(assertEqual( [[0 arg]],     0 ))
+    count(assertEqual( [[-1 arg]],    math.pi, 1e-6 ))
     count(assertEqual( [[-8 chs]],    8))   -- Change Sign
     count(assertEqual( [[8 chs]],     -8))
 
@@ -222,7 +232,6 @@ M.run = function(verbose)
     count(assertEqual( [[-3,1 arg]],     2.8198420991932, 1e-6 ))
     count(assertEqual( [[-3,-2 arg]],     -2.5535900500422, 1e-6 ))
     count(assertEqual( [[2,-1 arg]],     -0.46364760900081, 1e-6 ))
-    count(assertEqual( [[1 arg]],       'nan' ))
 
     count(assertEqual( [[-8,2 chs]],    {8,-2} ))   -- Change Sign
 

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -275,5 +275,12 @@ M.run = function(verbose)
     count(assertEqual( [[1,2 sech]], {-0.413149344,-0.687527439}, 1e-6))
     count(assertEqual( [[1,2 coth]], {0.821329797,0.171383613}, 1e-6))
 
+    count(assertEqual( [[1,1 asin]], {0.666239432,1.061275062}, 1e-6))
+    count(assertEqual( [[1,1 acos]], {0.904556894,-1.061275062}, 1e-6))
+    count(assertEqual( [[1,1 atan]], {1.017221968,0.402359478}, 1e-6))
+    count(assertEqual( [[1,1 acsc]], {0.452278447,-0.530637531}, 1e-6))
+    count(assertEqual( [[1,1 asec]], {1.118517880,0.530637531}, 1e-6))
+    count(assertEqual( [[1,1 acot]], {0.553574359,-0.402359478}, 1e-6))
+
     print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -124,13 +124,13 @@ M.run = function(verbose)
     tally(assert( [[2 exp]],       7.3890560989, 1e-6))  -- Raise e to the x power
     tally(assert( [[0 exp]],       1))
     tally(assert( [[0.1 exp]],     1.1051709180, 1e-6))
-    tally(assert( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
-    tally(assert( [[0 log]],       '-Infinity'))
+    tally(assert( [[120 ln]],     4.7874917427, 1e-6))  -- Natural log of x
+    tally(assert( [[0 ln]],       '-Infinity'))
     tally(assert( [[625 5 logx]],  4))  -- Log (base x) of y
     tally(assert( [[625 -5 logx]], 'NaN'))
     tally(assert( [[-625 5 logx]], 'NaN'))
-    tally(assert( [[1000 log10]],  3))  -- Log (base 10) of x
-    tally(assert( [[12345 log10]], 4.0914910942, 1e-6))
+    tally(assert( [[1000 log]],  3))  -- Log (base 10) of x
+    tally(assert( [[12345 log]], 4.0914910942, 1e-6))
     tally(assert( [[1024 log2]],   10))  -- Log (base 2) of x
     tally(assert( [[13 log2]],     3.7004397181, 1e-6))
     tally(assert( [[36 sqrt]],     6))  -- Square Root
@@ -249,8 +249,8 @@ M.run = function(verbose)
 
     print('Powers & Logs ===============================================================')
     tally(assert( [[2,1 exp]],      {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the x power
-    tally(assert( [[2,3 log]],      {1.282474678,0.982793723}, 1e-6 ))  -- Natural log of x
-    tally(assert( [[2,3 log10]],    {0.556971676,0.426821891}, 1e-6 ))  -- Log (base 10) of x
+    tally(assert( [[2,3 ln]],      {1.282474678,0.982793723}, 1e-6 ))  -- Natural log of x
+    tally(assert( [[2,3 log]],    {0.556971676,0.426821891}, 1e-6 ))  -- Log (base 10) of x
     tally(assert( [[2,3 log2]],     {1.850219859,1.417871631}, 1e-6 ))  -- Log (base 2) of x
     tally(assert( [[2,3 1,2 logx]], {1.131731655,-0.335771298}, 1e-6 ))  -- Log (base x) of y
     tally(assert( [[-4 sqrt]],      {0,2}, 1e-6))  -- Square root

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -7,19 +7,42 @@ local mockRequest = function(str)
 end
 
 local assertEqual = function(expression, expected, tolerance)
-    local msg = tolerance
-        and string.format('    %25s  should equal  %15s ± %-15s', expression, expected, tolerance)
-        or  string.format('    %25s  should equal  %15s', expression, expected)
+    local msg = type(expected) == 'table'
+        and string.format('    %25s  should equal {%s, %s} ', expression, expected[1], expected[2])
+        or string.format('    %25s  should equal  %s ', expression, expected)
+    msg = msg .. (tolerance
+        and string.format('± %-15s', tolerance)
+        or  '')
     local pass = false
     local checkResult = function(response)
         local result = response.items[1].textEdit.newText
         if type(expected) == 'string' then
-            pass = result == expected
+            local s,e = vim.regex([[^]]..expected..[[$]]):match_str(result)
+            pass = s and e
         else
             tolerance = tolerance or 0
-            pass = (expected-tolerance <= tonumber(result) and tonumber(result) <= expected+tolerance)
+            if type(expected) == 'table' then
+                -- Split complex into real and imaginary: "1.23+4.5i" -> {"1.23", "+4.5"}
+                local parts = vim.fn.split(result, '\\(\\ze[+-]\\|i\\)')
+                -- Side effect: it also splits mantissas from exponents: "1.2e-6+9.9e-8i" -> {"1.2e", "-6", "+9.9e", "-8"}
+                -- If that happens, smash them back together again: -> {"1.2e-6", "+9.9e-8"}
+                local i = 1
+                while i < #parts do
+                    if string.match(parts[i],'[Ee]$') then
+                        parts[i] = parts[i] .. parts[i+1]
+                        table.remove(parts, i+1)
+                    end
+                    i = i + 1
+                end
+
+                pass = #parts == #expected and
+                    math.abs(tonumber(parts[1])-expected[1]) <= tolerance and
+                    math.abs(tonumber(parts[2])-expected[2]) <= tolerance
+            else
+                pass = math.abs(tonumber(result)-expected) <= tolerance
+            end
         end
-        msg = msg .. (pass and '' or ('  Got ' .. result))
+        msg = msg .. (pass and '' or '  Got "' .. result .. '"')
     end
     require('cmp_rpncalc').complete(0, mockRequest(expression), checkResult)
     if printAll or not pass then
@@ -47,130 +70,207 @@ M.run = function(verbose)
         failedTests = failedTests + (pass and 0 or 1)
     end
 
+    print('No Operator (return the input) ==============================================')
+    count(assertEqual( [[12]],       [[12]] ))
+    count(assertEqual( [[1 2 3 4]],  [[1 2 3 4]] ))
+
     print('Basic Arithmetic ============================================================')
-    count(assertEqual('3 2 +',     5))   -- Addtion
-    count(assertEqual('3.1 2.2 +', 5.3))
-    count(assertEqual('13 2 -',    11))  -- Subtraction
-    count(assertEqual('1.3 2 -',   -0.7))
-    count(assertEqual('14 3 *',    42))  -- Multiplication
-    count(assertEqual('1.4 .3 *',  0.42))
-    count(assertEqual('24 8 /',    3))   -- Division
-    count(assertEqual('8 24 /',    0.333333333333, 1e-6))
-    count(assertEqual('7 0 /',     'inf'))
-    count(assertEqual('0 0 /',     'nan'))
-    count(assertEqual('23 5 div',  4))   -- Integer part of division
-    count(assertEqual('-23 5 div', -4))
-    count(assertEqual('23 5 %',    3))   -- Remainder of division
-    count(assertEqual('23 -5 %',   -2))
-    count(assertEqual('-23 5 %',   2))
-    count(assertEqual('-23 -5 %',  -3))
-    count(assertEqual('7 abs',     7))   -- Absolute Value
-    count(assertEqual('-7 abs',    7))
-    count(assertEqual('-8 chs',    8))   -- Change Sign
-    count(assertEqual('8 chs',     -8))
+    count(assertEqual( [[3 2 +]],     5))   -- Addtion
+    count(assertEqual( [[3.1 2.2 +]], 5.3))
+    count(assertEqual( [[13 2 -]],    11))  -- Subtraction
+    count(assertEqual( [[1.3 2 -]],   -0.7))
+    count(assertEqual( [[14 3 *]],    42))  -- Multiplication
+    count(assertEqual( [[1.4 .3 *]],  0.42))
+    count(assertEqual( [[24 8 /]],    3))   -- Division
+    count(assertEqual( [[8 24 /]],    0.333333333333, 1e-6))
+    count(assertEqual( [[7 0 /]],     'inf'))
+    count(assertEqual( [[0 0 /]],     'nan'))
+    count(assertEqual( [[23 5 div]],  4))   -- Integer part of division
+    count(assertEqual( [[-23 5 div]], -4))
+    count(assertEqual( [[23 5 %]],    3))   -- Remainder of division
+    count(assertEqual( [[23 -5 %]],   -2))
+    count(assertEqual( [[-23 5 %]],   2))
+    count(assertEqual( [[-23 -5 %]],  -3))
+    count(assertEqual( [[7 abs]],     7))   -- Absolute Value
+    count(assertEqual( [[-7 abs]],    7))
+    count(assertEqual( [[-8 chs]],    8))   -- Change Sign
+    count(assertEqual( [[8 chs]],     -8))
 
     print('Rounding ====================================================================')
-    count(assertEqual('12.3 floor',  12))  -- Floor - round down to nearest integer
-    count(assertEqual('-12.3 floor', -13))
-    count(assertEqual('12.3 ceil',   13))  -- Ceiling - round up to nearest integer
-    count(assertEqual('-12.3 ceil',  -12))
-    count(assertEqual('12.3 round',  12))  -- Round to nearest integer
-    count(assertEqual('-12.3 round', -12))
-    count(assertEqual('12.7 round',  13))
-    count(assertEqual('-12.7 round', -13))
-    count(assertEqual('12.7 trunc',  12))  -- Round toward zero
-    count(assertEqual('-12.7 trunc', -12))
+    count(assertEqual( [[12.3 floor]],  12 ))  -- Floor - round down to nearest integer
+    count(assertEqual( [[-12.3 floor]], -13 ))
+    count(assertEqual( [[12.3 ceil]],   13 ))  -- Ceiling - round up to nearest integer
+    count(assertEqual( [[-12.3 ceil]],  -12 ))
+    count(assertEqual( [[12.3 round]],  12 ))  -- Round to nearest integer
+    count(assertEqual( [[-12.3 round]], -12 ))
+    count(assertEqual( [[12.7 round]],  13 ))
+    count(assertEqual( [[-12.7 round]], -13 ))
+    count(assertEqual( [[12.7 trunc]],  12 ))  -- Round toward zero
+    count(assertEqual( [[-12.7 trunc]], -12 ))
 
     print('Powers & Logs ===============================================================')
-    count(assertEqual('2 exp',       7.3890560989, 1e-6))  -- Raise e to the x power
-    count(assertEqual('0 exp',       1))
-    count(assertEqual('0.1 exp',     1.1051709180, 1e-6))
-    count(assertEqual('120 log',     4.7874917427, 1e-6))  -- Natural log of x
-    count(assertEqual('0 log',       '-inf'))
-    count(assertEqual('625 5 logx',  4))  -- Log y of x
-    count(assertEqual('625 -5 logx', 'nan'))
-    count(assertEqual('-625 5 logx', 'nan'))
-    count(assertEqual('1000 log10',  3))  -- Log (base 10) of x
-    count(assertEqual('12345 log10', 4.0914910942, 1e-6))
-    count(assertEqual('1024 log2',   10))  -- Log (base 2) of x
-    count(assertEqual('13 log2',     3.7004397181, 1e-6))
-    count(assertEqual('36 sqrt',     6))  -- Square Root
-    count(assertEqual('-4 sqrt',     'nan'))
-    count(assertEqual('23.1 sqrt',   4.8062459362, 1e-6))
-    count(assertEqual('2 3 **',      8))  -- Exponentiation
-    count(assertEqual('-12 4 **',    20736))
-    count(assertEqual('-7 3.3 **',   'nan'))
-    count(assertEqual('0 0 **',      'nan'))
-    count(assertEqual('12 -0.25 **', 0.5372849659, 1e-6))
-    count(assertEqual('10 \\',       0.1))  -- Reciprocal
-    count(assertEqual('0 \\',        'inf'))
+    count(assertEqual( [[2 exp]],       7.3890560989, 1e-6))  -- Raise e to the x power
+    count(assertEqual( [[0 exp]],       1))
+    count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6))
+    count(assertEqual( [[120 log]],     4.7874917427, 1e-6))  -- Natural log of x
+    count(assertEqual( [[0 log]],       '-inf'))
+    count(assertEqual( [[625 5 logx]],  4))  -- Log y of x
+    count(assertEqual( [[625 -5 logx]], 'nan'))
+    count(assertEqual( [[-625 5 logx]], 'nan'))
+    count(assertEqual( [[1000 log10]],  3))  -- Log (base 10) of x
+    count(assertEqual( [[12345 log10]], 4.0914910942, 1e-6))
+    count(assertEqual( [[1024 log2]],   10))  -- Log (base 2) of x
+    count(assertEqual( [[13 log2]],     3.7004397181, 1e-6))
+    count(assertEqual( [[36 sqrt]],     6))  -- Square Root
+    count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6))
+    count(assertEqual( [[2 3 **]],      8))  -- Exponentiation
+    count(assertEqual( [[-12 4 **]],    20736))
+    count(assertEqual( [[-7 3.3 **]],   'nan'))
+    count(assertEqual( [[0 0 **]],      'nan'))
+    count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6))
+    count(assertEqual( [[10 \]],        0.1))  -- Reciprocal
+    count(assertEqual( [[0 \]],         'inf'))
 
     print('Trigonometry ================================================================')
-    count(assertEqual('1.5707963267 deg', 90,           1e-6))  -- convert x to degrees
-    count(assertEqual('90 rad',           1.5707963267, 1e-6))  -- convert x to radians
+    count(assertEqual( [[pi 2 / deg]], 90,           1e-6))  -- convert x to degrees
+    count(assertEqual( [[90 rad]],     1.5707963267, 1e-6))  -- convert x to radians
 
-    count(assertEqual('30 rad sin', 0.5))  -- Sine
-    count(assertEqual('60 rad cos', 0.5))  -- Cosine
-    count(assertEqual('45 rad tan', 1.0))  -- Tangent
-    -- count(assertEqual('90 rad tan', 'inf'))  -- The actual is VERY large, but not inf.
-    count(assertEqual('30 rad csc', 2.0))  -- Cosecant
-    count(assertEqual('60 rad sec', 2.0))  -- Secant
-    count(assertEqual('45 rad cot', 1.0))  -- Cotangent
-    count(assertEqual('0 cot',      'inf'))  -- Cotangent
+    count(assertEqual( [[30 rad sin]], 0.5 ))  -- Sine
+    count(assertEqual( [[60 rad cos]], 0.5 ))  -- Cosine
+    count(assertEqual( [[45 rad tan]], 1.0 ))  -- Tangent
+    -- count(assertEqual( [[90 rad tan]], 'inf' ))  -- The actual is VERY large, but not inf.
+    count(assertEqual( [[30 rad csc]], 2.0 ))  -- Cosecant
+    count(assertEqual( [[60 rad sec]], 2.0 ))  -- Secant
+    count(assertEqual( [[45 rad cot]], 1.0 ))  -- Cotangent
+    count(assertEqual( [[0 cot]],      'inf' ))  -- Cotangent
 
-    count(assertEqual('0.5 asin deg', 30.0))  -- Inverse sine
-    count(assertEqual('10 asin',      'nan'))
-    count(assertEqual('0.5 acos deg', 60.0))  -- Inverse cosine
-    count(assertEqual('-10 acos',     'nan'))
-    count(assertEqual('1 atan deg',   45.0))    -- Inverse Tangent
-    count(assertEqual('2.0 acsc deg', 30.0))  -- Inverse cosecant
-    count(assertEqual('0 acsc',       'nan'))  -- Inverse cosecant
-    count(assertEqual('2.0 asec deg', 60.0))  -- Inverse secant
-    count(assertEqual('0 asec',       'nan'))  -- Inverse secant
-    count(assertEqual('1 acot deg',   45.0))  -- Inverse cotangent
+    count(assertEqual( [[0.5 asin deg]], 30 ))  -- Inverse sine
+    count(assertEqual( [[10 asin]],      'nan' ))
+    count(assertEqual( [[0.5 acos deg]], 60 ))  -- Inverse cosine
+    count(assertEqual( [[-10 acos]],     'nan' ))
+    count(assertEqual( [[1 atan deg]],   45 ))    -- Inverse Tangent
+    count(assertEqual( [[2.0 acsc deg]], 30 ))  -- Inverse cosecant
+    count(assertEqual( [[0 acsc]],       'nan' ))  -- Inverse cosecant
+    count(assertEqual( [[2.0 asec deg]], 60 ))  -- Inverse secant
+    count(assertEqual( [[0 asec]],       'nan' ))  -- Inverse secant
+    count(assertEqual( [[1 acot deg]],   45 ))  -- Inverse cotangent
 
-    count(assertEqual('2 sinh',             3.6268604079, 1e-6)) -- Hyperbolic sine
-    count(assertEqual('4 cosh',             27.308232836, 1e-6)) -- Hyperbolic cosine
-    count(assertEqual('-0.5 tanh',          -0.462117157, 1e-6)) -- Hyperbolic tangent
-    count(assertEqual('3.6268604079 asinh', 2.0,          1e-6)) -- Inverse hyperbolic sine
-    count(assertEqual('27.30823284 acosh',  4.0,          1e-6)) -- Inverse hyperbolic cosine
-    count(assertEqual('0 acosh',            'nan'))
-    count(assertEqual('-0.462117157 atanh', -0.5,         1e-6)) -- Inverse hyperbolic tangent
-    count(assertEqual('1 atanh',            'inf'))
-    count(assertEqual('-1 atanh',           '-inf'))
-    count(assertEqual('10 atanh',           'nan'))
+    count(assertEqual( [[2 sinh]],             3.6268604078, 1e-6 )) -- Hyperbolic sine
+    count(assertEqual( [[4 cosh]],             27.308232836, 1e-6 )) -- Hyperbolic cosine
+    count(assertEqual( [[-0.5 tanh]],          -0.462117157, 1e-6 )) -- Hyperbolic tangent
+    count(assertEqual( [[3.6268604079 asinh]], 2.0, 1e-6 )) -- Inverse hyperbolic sine
+    count(assertEqual( [[27.30823284 acosh]],  4.0, 1e-6 )) -- Inverse hyperbolic cosine
+    count(assertEqual( [[0 acosh]],            'nan' ))
+    count(assertEqual( [[-0.462117157 atanh]], -0.5, 1e-6 )) -- Inverse hyperbolic tangent
+    count(assertEqual( [[1 atanh]],            'inf' ))
+    count(assertEqual( [[-1 atanh]],           '-inf' ))
+    count(assertEqual( [[10 atanh]],           'nan' ))
 
-    count(assertEqual('2 csch',              0.27572056,    1e-6))  -- Hyperbolic cosecant
-    count(assertEqual('0 csch',              'inf'))
-    count(assertEqual('-5 sech',             0.013475282,   1e-6))  -- Hyperbolic secant
-    count(assertEqual('0 sech',              1.0))
-    count(assertEqual('0.5 coth',            2.16395341373, 1e-6))  -- Hyperbolic cotangent
-    count(assertEqual('0 coth',              'inf'))
-    count(assertEqual('0.27572056 acsch',    2.0,           1e-6))  -- Inverse hyperbolic cosecant
-    count(assertEqual('0 acsch',             'inf'))
-    count(assertEqual('0.013475282 asech',   5.0,           1e-6))  -- Inverse hyperbolic secant
-    count(assertEqual('-1 asech',            'nan'))
-    count(assertEqual('2.16395341373 acoth', 0.5,           1e-6))  -- Inverse hyperbolic cotangent
-    count(assertEqual('0 acoth',             'nan'))
+    count(assertEqual( [[2 csch]],              0.27572056, 1e-6 ))  -- Hyperbolic cosecant
+    count(assertEqual( [[0 csch]],              'inf' ))
+    count(assertEqual( [[-5 sech]],             0.013475282, 1e-6 ))  -- Hyperbolic secant
+    count(assertEqual( [[0 sech]],              1 ))
+    count(assertEqual( [[0.5 coth]],            2.16395341373, 1e-6 ))  -- Hyperbolic cotangent
+    count(assertEqual( [[0 coth]],              'inf' ))
+    count(assertEqual( [[0.27572056 acsch]],    2.0, 1e-6 ))  -- Inverse hyperbolic cosecant
+    count(assertEqual( [[0 acsch]],             'inf' ))
+    count(assertEqual( [[0.013475282 asech]],   5.0, 1e-6 ))  -- Inverse hyperbolic secant
+    count(assertEqual( [[-1 asech]],            'nan' ))
+    count(assertEqual( [[2.16395341373 acoth]], 0.5, 1e-6 ))  -- Inverse hyperbolic cotangent
+    count(assertEqual( [[0 acoth]],             'nan' ))
 
     print('Bitwise =====================================================================')
-    count(assertEqual('60 13 &', 12))   -- AND
-    count(assertEqual('60 13 |', 61))   -- OR
-    count(assertEqual('60 13 ^', 49))   -- XOR
-    count(assertEqual('60 ~',    -61))  -- NOT
-    count(assertEqual('60 2 <<', 240))  -- Left Shift
-    count(assertEqual('60 2 >>', 15))   -- Right Shift
+    count(assertEqual( [[60 13 &]], 12 ))   -- AND
+    count(assertEqual( [[60 13 |]], 61 ))   -- OR
+    count(assertEqual( [[60 13 ^]], 49 ))   -- XOR
+    count(assertEqual( [[60 ~]],    -61 ))  -- NOT
+    count(assertEqual( [[60 2 <<]], 240 ))  -- Left Shift
+    count(assertEqual( [[60 2 >>]], 15 ))   -- Right Shift
 
     print('Constants ===================================================================')
-    count(assertEqual('pi',  3.1415926535, 1e-6))  -- 3.141592653....
-    count(assertEqual('e',   2.7182818284, 1e-6))  -- 2.718281828...
-    count(assertEqual('phi', 1.6180339887, 1e-6))  -- golden ratio
+    count(assertEqual( [[pi]],  3.1415926535, 1e-6 ))  -- 3.141592653....
+    count(assertEqual( [[e]],   2.7182818284, 1e-6 ))  -- 2.718281828...
+    count(assertEqual( [[phi]], 1.6180339887, 1e-6 ))  -- golden ratio
+    count(assertEqual( [[i]],   {0,1} ))
 
     print('Other =======================================================================')
-    count(assertEqual('3 20 15 hrs', 3.3375))  -- Convert Z:Y:X to hours
-    count(assertEqual('3.3375 hms', '3 20 15'))  -- Convert X hours to Z:Y:X
+    count(assertEqual( [[3 20 15 hrs]], 3.3375 ))  -- Convert Z:Y:X to hours
+    count(assertEqual( [[3.3375 hms]], [[3 20 15]] ))  -- Convert X hours to Z:Y:X
 
-    print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests))
-end
+    print('AGAIN, BUT WITH COMPLEX NUMBERS ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~=~')
 
+    print('No Operator (return the input) ==============================================')
+    count(assertEqual( [[12,2]],       {12,2} ))
+    count(assertEqual( [[1,-2 3,4]],  [[1-2i 3+4i]] ))
+
+    print('Basic Arithmetic ============================================================')
+    count(assertEqual( [[3,1  2,6 +]],    {5,7} ))   -- Addtion
+    count(assertEqual( [[3.5  2,6 +]],    {5.5,6} ))
+    count(assertEqual( [[3,1  6 +]],      {9,1} ))
+    count(assertEqual( [[13,4 2,2 -]],    {11,2} ))  -- Subtraction
+    count(assertEqual( [[13   2,2 -]],    {11,-2} ))
+    count(assertEqual( [[13,4 2 -]],      {11,4} ))
+    count(assertEqual( [[1,4  3,2 *]],    {-5,14} ))  -- Multiplication
+    count(assertEqual( [[4    3,2 *]],    {12,8} ))
+    count(assertEqual( [[1,4  3 *]],      {3,12} ))
+    count(assertEqual( [[2,4  2 /]],      {1,2} ))   -- Division
+    count(assertEqual( [[2    4,2 /]],    {0.4,-0.2} ))
+    count(assertEqual( [[3,-1 4,2 /]],    {0.5,-0.5} ))
+
+    count(assertEqual( [[3,4 abs]],     5 ))   -- Absolute Value
+
+    count(assertEqual( [[1,1 arg]],     0.78539816339745, 1e-6 ))  -- Arg
+    count(assertEqual( [[-3,1 arg]],     2.8198420991932, 1e-6 ))
+    count(assertEqual( [[-3,-2 arg]],     -2.5535900500422, 1e-6 ))
+    count(assertEqual( [[2,-1 arg]],     -0.46364760900081, 1e-6 ))
+    count(assertEqual( [[1 arg]],       'nan' ))
+
+    count(assertEqual( [[-8,2 chs]],    {8,-2} ))   -- Change Sign
+
+    print('Rounding ====================================================================')
+    count(assertEqual( [[12.3,4.2 floor]],   {12,4} ))  -- Floor - round down to nearest integer
+    count(assertEqual( [[-12.3,-4.2 floor]], {-13,-5} ))
+    count(assertEqual( [[12.3,4.2 ceil]],    {13,5} ))  -- Ceiling - round up to nearest integer
+    count(assertEqual( [[-12.3,-4.2 ceil]],  {-12,-4} ))
+    count(assertEqual( [[12.3,4.7 round]],   {12,5} ))  -- Round to nearest integer
+    count(assertEqual( [[-12.3,-4.7 round]], {-12,-5} ))
+    count(assertEqual( [[12.7,4.3 round]],   {13,4} ))
+    count(assertEqual( [[-12.7,-4.3 round]], {-13,-4} ))
+    count(assertEqual( [[12.7,4.3 trunc]],   {12,4} ))  -- Round toward zero
+    count(assertEqual( [[-12.7,-4.3 trunc]], {-12,-4} ))
+
+    print('Powers & Logs ===============================================================')
+    -- count(assertEqual( [[2,1 exp]],   {3.992324048,6.217676312}, 1e-6 )) -- Raise e to the a complex power
+
+-- e^(a+bi)
+-- (e^a)*(e*bi)
+-- (e^a)*(cos(b)+i*sin(b))
+-- {(e^a)cos(b), (e^a)sin(b)}
+
+
+    -- count(assertEqual( [[0.1 exp]],     1.1051709180, 1e-6 ))
+    -- count(assertEqual( [[120 log]],     4.7874917427, 1e-6 ))  -- Natural log of x
+    -- count(assertEqual( [[0 log]],       '-inf' ))
+    -- count(assertEqual( [[625 5 logx]],  4 ))  -- Log y of x
+    -- count(assertEqual( [[625 -5 logx]], 'nan' ))
+    -- count(assertEqual( [[-625 5 logx]], 'nan' ))
+    -- count(assertEqual( [[1000 log10]],  3 ))  -- Log (base 10) of x
+    -- count(assertEqual( [[12345 log10]], 4.0914910942, 1e-6 ))
+    -- count(assertEqual( [[1024 log2]],   10 ))  -- Log (base 2) of x
+    -- count(assertEqual( [[13 log2]],     3.7004397181, 1e-6 ))
+    -- count(assertEqual( [[36 sqrt]],     6 ))  -- Square Root
+    count(assertEqual( [[-4 sqrt]],     {0,2} ))
+    -- count(assertEqual( [[23.1 sqrt]],   4.8062459362, 1e-6 ))
+    count(assertEqual( [[0,1 2 **]],      {-1,0}, 1e-6 ))  -- Exponentiation
+    count(assertEqual( [[0,1 3 **]],    {0,-1}, 1e-6 ))
+    count(assertEqual( [[1,1 2 **]],    {0,2}, 1e-6 ))
+    count(assertEqual( [[3 1,-2 **]],   {-1.7587648,-2.4303798}, 1e-6))
+    count(assertEqual( [[-4,3 1,-2 **]],   {555.3814991,-487.8784553}, 1e-6))
+    -- count(assertEqual( [[-7 3.3 **]],   'nan' ))
+    -- count(assertEqual( [[0 0 **]],      'nan' ))
+    -- count(assertEqual( [[12 -0.25 **]], 0.5372849659, 1e-6 ))
+    -- count(assertEqual( [[10 \]],       0.1 ))  -- Reciprocal
+    -- count(assertEqual( [[0 \]],        'inf' ))
+
+    print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M

--- a/lua/cmp_rpncalc/tests.lua
+++ b/lua/cmp_rpncalc/tests.lua
@@ -161,7 +161,6 @@ M.run = function(verbose)
     count(assertEqual( [[-0.5 tanh]],          -0.462117157, 1e-6 )) -- Hyperbolic tangent
     count(assertEqual( [[3.6268604079 asinh]], 2.0, 1e-6 )) -- Inverse hyperbolic sine
     count(assertEqual( [[27.30823284 acosh]],  4.0, 1e-6 )) -- Inverse hyperbolic cosine
-    count(assertEqual( [[0 acosh]],            'nan' ))
     count(assertEqual( [[-0.462117157 atanh]], -0.5, 1e-6 )) -- Inverse hyperbolic tangent
     count(assertEqual( [[1 atanh]],            'inf' ))
     count(assertEqual( [[-1 atanh]],           '-inf' ))
@@ -176,7 +175,6 @@ M.run = function(verbose)
     count(assertEqual( [[0.27572056 acsch]],    2.0, 1e-6 ))  -- Inverse hyperbolic cosecant
     count(assertEqual( [[0 acsch]],             'inf' ))
     count(assertEqual( [[0.013475282 asech]],   5.0, 1e-6 ))  -- Inverse hyperbolic secant
-    count(assertEqual( [[-1 asech]],            'nan' ))
     count(assertEqual( [[2.16395341373 acoth]], 0.5, 1e-6 ))  -- Inverse hyperbolic cotangent
     count(assertEqual( [[0 acoth]],             'nan' ))
 
@@ -281,6 +279,13 @@ M.run = function(verbose)
     count(assertEqual( [[1,1 acsc]], {0.452278447,-0.530637531}, 1e-6))
     count(assertEqual( [[1,1 asec]], {1.118517880,0.530637531}, 1e-6))
     count(assertEqual( [[1,1 acot]], {0.553574359,-0.402359478}, 1e-6))
+
+    count(assertEqual( [[1,1 asinh]], {1.061275062,0.666239432}, 1e-6))
+    count(assertEqual( [[1,1 acosh]], {1.061275062,0.904556894}, 1e-6))
+    count(assertEqual( [[1,1 atanh]], {0.402359478,1.017221968}, 1e-6))
+    count(assertEqual( [[1,1 acsch]], {0.530637531,-0.452278447}, 1e-6))
+    count(assertEqual( [[1,1 asech]], {0.530637531,-1.118517880}, 1e-6))
+    count(assertEqual( [[1,1 acoth]], {0.402359478,-0.553574359}, 1e-6))
 
     print(string.format('\n%4d test(s) passed.  %4d test(s) failed.', passedTests, failedTests)) end
 return M


### PR DESCRIPTION
1. To push a complex number on the stack, enter it as an ordered pair without spaces: `real,imaginary`, eg. `1.2,-3` for `1.2-3i`. Purely imaginary numbers still require the real part: `0,5i`, for example.
1. Added a the complex constant: `i`
1. Added a new function: `arg`, the angle between X and the x-axis. (This equates to pi for negative real numbes and 0 for non-negative reals.)
1. All functions in **Basic Arithmetic** (except `%`), **Powers & Logs**, **Trigonometry**, and **Rounding** now operate on complex numbers.
1. Added new unit tests for all the operands' processing of complex numbers. I'm sure many more could be added.
1. Improved the way infinity and NaN results were reported.
1. Updated the README and documentation.
